### PR TITLE
Integrate FinancialEngine-based franchise financials and add per-project badges; log streaming revenue through transactions

### DIFF
--- a/src/components/game/EnhancedFranchiseSystem.tsx
+++ b/src/components/game/EnhancedFranchiseSystem.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { Crown, Star, Users, Plus, TrendingUp, Film } from 'lucide-react';
+import { FinancialEngine } from './FinancialEngine';
 
 interface EnhancedFranchiseSystemProps {
   gameState: GameState;
@@ -47,10 +48,9 @@ export const EnhancedFranchiseSystem: React.FC<EnhancedFranchiseSystemProps> = (
   // Calculate franchise performance metrics (films + TV/streaming)
   const getFranchiseMetrics = (franchise: Franchise) => {
     const franchiseProjects = gameState.projects.filter(p => p.script.franchiseId === franchise.id);
-    const totalBoxOffice = franchiseProjects.reduce(
-      (sum, p) => sum + (p.metrics?.boxOfficeTotal || 0),
-      0
-    );
+    const financials = FinancialEngine.getFranchiseFinancials(franchiseProjects);
+
+    const totalBoxOffice = financials.boxOfficeRevenue;
     const totalBudget = franchiseProjects.reduce((sum, p) => sum + p.budget.total, 0);
     const avgCriticsScore =
       franchiseProjects.length > 0
@@ -69,19 +69,16 @@ export const EnhancedFranchiseSystem: React.FC<EnhancedFranchiseSystemProps> = (
       0
     );
 
-    // Rough combined valuation: 30% of box office plus value from streaming views
-    const streamingValue = (totalStreamingViews / 1_000_000) * 3_000_000;
-    const franchiseValue = totalBoxOffice * 0.3 + streamingValue;
-
     return {
       projectCount: franchiseProjects.length,
       totalBoxOffice,
       totalBudget,
       totalStreamingViews,
-      profitability: totalBudget > 0 ? ((totalBoxOffice - totalBudget) / totalBudget) * 100 : 0,
+      profitability:
+        totalBudget > 0 ? ((financials.totalRevenue - totalBudget) / totalBudget) * 100 : 0,
       avgCriticsScore,
       avgAudienceScore,
-      franchiseValue
+      franchiseValue: financials.totalRevenue
     };
   };
 
@@ -398,9 +395,21 @@ export const EnhancedFranchiseSystem: React.FC<EnhancedFranchiseSystemProps> = (
                                 </div>
                               </div>
                             </div>
-                            <Badge variant={project.status === 'released' ? "default" : "secondary"}>
-                              {project.status}
-                            </Badge>
+                            <div className="flex flex-col items-end gap-1">
+                              <Badge variant="outline" className="text-xs capitalize">
+                                {project.type === 'feature'
+                                  ? 'Film'
+                                  : project.type === 'documentary'
+                                  ? 'Doc'
+                                  : 'TV'}
+                              </Badge>
+                              <Badge
+                                variant={project.status === 'released' ? "default" : "secondary"}
+                                className="text-xs"
+                              >
+                                {project.status}
+                              </Badge>
+                            </div>
                           </div>
                         ))}
                     </div>

--- a/src/components/game/FinancialEngine.tsx
+++ b/src/components/game/FinancialEngine.tsx
@@ -218,6 +218,63 @@ export class FinancialEngine {
       transactions: filmTransactions
     };
   }
+
+  static getFranchiseFinancials(projects: Project[]): {
+    totalRevenue: number;
+    boxOfficeRevenue: number;
+    streamingRevenue: number;
+    otherRevenue: number;
+    totalExpenses: number;
+    netProfit: number;
+  } {
+    this.ensureLoaded();
+
+    if (!projects.length) {
+      return {
+        totalRevenue: 0,
+        boxOfficeRevenue: 0,
+        streamingRevenue: 0,
+        otherRevenue: 0,
+        totalExpenses: 0,
+        netProfit: 0
+      };
+    }
+
+    const projectIds = new Set(projects.map(p => p.id));
+    const relevant = this.transactions.filter(
+      t => t.filmId && projectIds.has(t.filmId)
+    );
+
+    let boxOfficeRevenue = 0;
+    let streamingRevenue = 0;
+    let otherRevenue = 0;
+    let totalExpenses = 0;
+
+    relevant.forEach(t => {
+      if (t.type === 'revenue') {
+        if (t.category === 'boxoffice') {
+          boxOfficeRevenue += t.amount;
+        } else if (t.category === 'streaming') {
+          streamingRevenue += t.amount;
+        } else {
+          otherRevenue += t.amount;
+        }
+      } else {
+        totalExpenses += t.amount;
+      }
+    });
+
+    const totalRevenue = boxOfficeRevenue + streamingRevenue + otherRevenue;
+
+    return {
+      totalRevenue,
+      boxOfficeRevenue,
+      streamingRevenue,
+      otherRevenue,
+      totalExpenses,
+      netProfit: totalRevenue - totalExpenses
+    };
+  }
   
   static getRecentTransactions(count: number = 10): Transaction[] {
     this.ensureLoaded();

--- a/src/components/game/FranchiseProjectCreator.tsx
+++ b/src/components/game/FranchiseProjectCreator.tsx
@@ -359,8 +359,20 @@ export const FranchiseProjectCreator: React.FC<FranchiseProjectCreatorProps> = (
                     <div className="space-y-1">
                       {franchiseProjects.slice(-3).map(project => (
                         <div key={project.id} className="flex items-center justify-between text-sm">
-                          <span>{project.title}</span>
-                          <Badge variant={project.status === 'released' ? 'default' : 'secondary'}>
+                          <span className="flex items-center gap-2">
+                            {project.title}
+                            <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                              {project.type === 'feature'
+                                ? 'Film'
+                                : project.type === 'documentary'
+                                ? 'Doc'
+                                : 'TV'}
+                            </Badge>
+                          </span>
+                          <Badge
+                            variant={project.status === 'released' ? 'default' : 'secondary'}
+                            className="text-xs"
+                          >
                             {project.status}
                           </Badge>
                         </div>

--- a/src/components/game/OwnedFranchiseManager.tsx
+++ b/src/components/game/OwnedFranchiseManager.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Crown, Edit3, TrendingUp, Users, DollarSign, Star, Calendar } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { FinancialEngine } from './FinancialEngine';
 
 interface OwnedFranchiseManagerProps {
   gameState: GameState;
@@ -38,7 +39,8 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
   // Calculate franchise metrics
   const getFranchiseMetrics = (franchise: Franchise) => {
     const franchiseProjects = gameState.projects.filter(p => p.script.franchiseId === franchise.id);
-    const totalBoxOffice = franchiseProjects.reduce((sum, p) => sum + (p.metrics?.boxOfficeTotal || 0), 0);
+    const financials = FinancialEngine.getFranchiseFinancials(franchiseProjects);
+    const totalBoxOffice = financials.boxOfficeRevenue;
     const totalBudget = franchiseProjects.reduce((sum, p) => sum + p.budget.total, 0);
     const avgCriticsScore = franchiseProjects.length > 0 
       ? franchiseProjects.reduce((sum, p) => sum + (p.metrics?.criticsScore || 0), 0) / franchiseProjects.length
@@ -48,9 +50,9 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
       projectCount: franchiseProjects.length,
       totalBoxOffice,
       totalBudget,
-      profitability: totalBudget > 0 ? ((totalBoxOffice - totalBudget) / totalBudget) * 100 : 0,
+      profitability: totalBudget > 0 ? ((financials.totalRevenue - totalBudget) / totalBudget) * 100 : 0,
       avgCriticsScore,
-      franchiseValue: totalBoxOffice * 0.3,
+      franchiseValue: financials.totalRevenue,
       projects: franchiseProjects
     };
   };
@@ -196,12 +198,12 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
                   </div>
                 </div>
 
-                {/* Franchise Films */}
+                {/* Franchise Projects */}
                 {metrics.projects.length > 0 && (
                   <div>
                     <h4 className="font-medium mb-3 flex items-center gap-2">
                       <Users className="h-4 w-4" />
-                      Franchise Films ({metrics.projects.length})
+                      Franchise Projects ({metrics.projects.length})
                     </h4>
                     <div className="grid gap-2">
                       {metrics.projects
@@ -220,9 +222,21 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
                                 </div>
                               </div>
                             </div>
-                            <Badge variant={project.status === 'released' ? "default" : "secondary"}>
-                              {project.status}
-                            </Badge>
+                            <div className="flex flex-col items-end gap-1">
+                              <Badge variant="outline" className="text-xs capitalize">
+                                {project.type === 'feature'
+                                  ? 'Film'
+                                  : project.type === 'documentary'
+                                  ? 'Doc'
+                                  : 'TV'}
+                              </Badge>
+                              <Badge
+                                variant={project.status === 'released' ? "default" : "secondary"}
+                                className="text-xs"
+                              >
+                                {project.status}
+                              </Badge>
+                            </div>
                           </div>
                         ))}
                     </div>

--- a/src/components/game/StreamingContractSystem.tsx
+++ b/src/components/game/StreamingContractSystem.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/hooks/use-toast';
 import { StreamingContract, StreamingProject } from '@/types/streamingTypes';
 import { GameState, Project } from '@/types/game';
 import { Monitor, DollarSign, Users, TrendingUp, Calendar, Award, AlertTriangle } from 'lucide-react';
+import { FinancialEngine } from './FinancialEngine';
 
 interface StreamingContractSystemProps {
   gameState: GameState;
@@ -147,6 +148,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
 
   const signContract = (project: Project, platformId: string) => {
     const contract = generateContract(project, platformId);
+    const platform = STREAMING_PLATFORMS.find(p => p.id === platformId)!;
     
     onProjectUpdate(project.id, {
       streamingContract: contract,
@@ -158,11 +160,20 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
     });
     
     onUpdateBudget(contract.upfrontPayment);
+
+    FinancialEngine.recordTransaction(
+      'revenue',
+      'streaming',
+      contract.upfrontPayment,
+      gameState.currentWeek,
+      gameState.currentYear,
+      `Streaming contract upfront - ${platform.name} - ${project.title}`,
+      project.id
+    );
     
-    const platform = STREAMING_PLATFORMS.find(p => p.id === platformId)!;
     toast({
       title: "Contract Signed!",
-      description: `Signed with ${platform.name} for $${(contract.upfrontPayment / 1000000).toFixed(1)}M upfront + performance bonuses`,
+      description: `Signed with ${platform.name} for ${(contract.upfrontPayment / 1000000).toFixed(1)}M upfront + performance bonuses`,
     });
     
     setSelectedProject(null);
@@ -174,6 +185,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
     
     const contract = project.streamingContract;
     const metrics = project.metrics.streaming;
+    const platform = STREAMING_PLATFORMS.find(p => p.id === contract.platform);
     
     // Calculate performance score
     const viewershipScore = Math.min(100, (metrics.totalViews / contract.expectedViewers) * 100);
@@ -207,17 +219,35 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
     
     if (bonusEarned > 0) {
       onUpdateBudget(bonusEarned);
+      FinancialEngine.recordTransaction(
+        'revenue',
+        'streaming',
+        bonusEarned,
+        gameState.currentWeek,
+        gameState.currentYear,
+        `Streaming performance bonus - ${platform?.name ?? contract.platform} - ${project.title}`,
+        project.id
+      );
       toast({
         title: "Performance Bonus!",
-        description: `Earned $${(bonusEarned / 1000000).toFixed(1)}M for exceeding viewership targets`,
+        description: `Earned ${(bonusEarned / 1000000).toFixed(1)}M for exceeding viewership targets`,
       });
     }
     
     if (penalty > 0) {
       onUpdateBudget(-penalty);
+      FinancialEngine.recordTransaction(
+        'expense',
+        'streaming',
+        penalty,
+        gameState.currentWeek,
+        gameState.currentYear,
+        `Streaming contract penalty - ${platform?.name ?? contract.platform} - ${project.title}`,
+        project.id
+      );
       toast({
         title: "Contract Penalty",
-        description: `Penalty of $${(penalty / 1000000).toFixed(1)}M for underperforming`,
+        description: `Penalty of ${(penalty / 1000000).toFixed(1)}M for underperforming`,
         variant: "destructive"
       });
     }


### PR DESCRIPTION
Summary of changes:
- EnhancedFranchiseSystem.tsx
  - Use FinancialEngine.getFranchiseFinancials to compute boxOfficeRevenue and totalRevenue for franchises.
  - Update totalBoxOffice to financials.boxOfficeRevenue; profitability now uses (financials.totalRevenue - totalBudget) / totalBudget.
  - Franchise value set to financials.totalRevenue.
  - Added per-project badges showing Film/Doc/TV alongside a status badge in the project list.

- FinancialEngine.tsx
  - Added getFranchiseFinancials(projects) to aggregate revenues (box office, streaming, other) and expenses for a set of projects and return totals including netProfit.

- FranchiseProjectCreator.tsx and OwnedFranchiseManager.tsx
  - Display per-project type badges (Film/Doc/TV) next to project titles and adjust project section headers from "Franchise Films" to "Franchise Projects".
  - Maintain status badges next to each project.

- StreamingContractSystem.tsx
  - Integrate FinancialEngine to record streaming-related transactions:
    - Upfront revenue when signing a contract.
    - Revenue/expense entries for bonuses and penalties.
  - Use platform data to label messages consistently.

How this solves the issue:
- Streaming revenue is now factored into franchise-level financials, providing a more accurate profitability and valuation.
- Users get clear, at-a-glance type badges (Film/Doc/TV) for projects, improving readability in franchise lists.
- All streaming-related economics are captured in the financial engine, enabling better tracking and reporting across contracts and performance outcomes.

---

> This pull request was co-created with Cosine Genie

Original Task: [studio-dynasty-builder/pdukok32eo8y](https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/pdukok32eo8y)
Author: Evan Lewis
