### PR TITLE
Episode tracking: add pre-release episode count edits and gating release planning on marketing progress

### DIFF
--- a/src/components/game/EpisodeTrackingSystem.tsx
+++ b/src/components/game/EpisodeTrackingSystem.tsx
@@ -97,6 +97,75 @@ export const EpisodeTrackingSystem: React.FC<EpisodeTrackingSystemProps> = ({
     toast({ title: "Episode Updated", description: `Episode ${episodeIndex + 1} details saved.` });
   };
 
+  // Update total number of episodes for the first season (pre-release)
+  const updateEpisodeCount = (project: Project, newTotal: number) => {
+    if (!project.seasons || project.seasons.length === 0) return;
+
+    const rawTotal = Math.floor(newTotal);
+    if (!Number.isFinite(rawTotal)) return;
+
+    // Keep seasons in a sensible TV range
+    const clampedTotal = Math.max(1, Math.min(26, rawTotal));
+
+    const updatedSeasons = [...project.seasons];
+    const seasonIndex = 0;
+    const season = { ...updatedSeasons[seasonIndex] };
+
+    const existingEpisodes = season.episodes || [];
+    if (clampedTotal === existingEpisodes.length) return;
+
+    const totalBudget = season.totalBudget || project.budget.total || 0;
+    const perEpisodeBudget = totalBudget > 0 ? totalBudget / clampedTotal : 0;
+    const baseRuntime = existingEpisodes[0]?.runtime || 45;
+
+    // Start with trimmed existing episodes
+    let episodes: EpisodeData[] = existingEpisodes
+      .slice(0, clampedTotal)
+      .map((ep, idx) => ({
+        ...ep,
+        episodeNumber: idx + 1,
+        productionCost: perEpisodeBudget,
+      }));
+
+    // Add new blank episodes if season is being extended
+    if (clampedTotal > existingEpisodes.length) {
+      const episodesToAdd = clampedTotal - existingEpisodes.length;
+      const startIndex = existingEpisodes.length;
+
+      for (let i = 0; i < episodesToAdd; i++) {
+        const episodeNumber = startIndex + i + 1;
+        episodes.push({
+          episodeNumber,
+          seasonNumber: season.seasonNumber || 1,
+          title: `Episode ${episodeNumber}`,
+          runtime: baseRuntime,
+          viewers: 0,
+          completionRate: 0,
+          averageWatchTime: 0,
+          replayViews: 0,
+          weeklyViews: [],
+          cumulativeViews: 0,
+          viewerRetention: 100,
+          productionCost: perEpisodeBudget,
+          socialMentions: 0,
+        });
+      }
+    } else if (season.episodesAired > clampedTotal) {
+      // If we reduced the order, clamp aired episodes to the new total
+      season.episodesAired = clampedTotal;
+    }
+
+    season.totalEpisodes = clampedTotal;
+    season.episodes = episodes;
+    updatedSeasons[seasonIndex] = season;
+
+    onProjectUpdate(project.id, { seasons: updatedSeasons });
+    toast({
+      title: "Season Updated",
+      description: `Season now has ${clampedTotal} episode${clampedTotal === 1 ? '' : 's'}.`,
+    });
+  };
+
   // Release episodes based on format
   const releaseEpisodes = (project: Project, format: 'weekly' | 'binge' | 'batch') => {
     // Get fresh project data to avoid stale state
@@ -400,6 +469,7 @@ export const EpisodeTrackingSystem: React.FC<EpisodeTrackingSystemProps> = ({
                           <EpisodeSetupPanel 
                             project={project} 
                             onUpdateEpisode={(idx, updates) => updateEpisode(project, idx, updates)}
+                            onUpdateEpisodeCount={(newTotal) => updateEpisodeCount(project, newTotal)}
                           />
                         </DialogContent>
                       </Dialog>
@@ -545,9 +615,10 @@ export const EpisodeTrackingSystem: React.FC<EpisodeTrackingSystemProps> = ({
 interface EpisodeSetupPanelProps {
   project: Project;
   onUpdateEpisode: (episodeIndex: number, updates: Partial<EpisodeData>) => void;
+  onUpdateEpisodeCount?: (newTotal: number) => void;
 }
 
-const EpisodeSetupPanel: React.FC<EpisodeSetupPanelProps> = ({ project, onUpdateEpisode }) => {
+const EpisodeSetupPanel: React.FC<EpisodeSetupPanelProps> = ({ project, onUpdateEpisode, onUpdateEpisodeCount }) => {
   const currentSeason = project.seasons?.[0];
   if (!currentSeason) return <p>No season data available.</p>;
   
@@ -558,6 +629,39 @@ const EpisodeSetupPanel: React.FC<EpisodeSetupPanelProps> = ({ project, onUpdate
           <strong>Customize your episodes before release.</strong> Set titles, runtime, descriptions, and assign directors/writers for each episode.
         </p>
       </div>
+
+      <div className="flex items-center justify-between mb-2">
+        <div>
+          <p className="text-sm font-medium">
+            Season {currentSeason.seasonNumber} • {currentSeason.totalEpisodes} episode{currentSeason.totalEpisodes === 1 ? '' : 's'}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Adjust the episode count before airing to match your season order.
+          </p>
+        </div>
+        {onUpdateEpisodeCount && (
+          <div className="flex items-center gap-2">
+            <Label htmlFor="episode-count" className="text-xs">
+              Episodes
+            </Label>
+            <Input
+              id="episode-count"
+              type="number"
+              min={1}
+              max={26}
+              value={currentSeason.totalEpisodes}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                if (!Number.isNaN(next)) {
+                  onUpdateEpisodeCount(next);
+                }
+              }}
+              className="w-20 h-8 text-xs"
+            />
+          </div>
+        )}
+      </div>
+
       <div className="grid gap-4">
         {currentSeason.episodes.map((episode, index) => (
           <Card key={index} className="p-4 border-l-4 border-l-primary/50">

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -2504,8 +2504,19 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
                       size="sm"
                       onClick={() => setFilmReleaseProject(selectedProject)}
                       disabled={
-                        selectedProject.status !== 'completed' &&
-                        selectedProject.status !== 'ready-for-release'
+                        !(
+                          // Require at least some marketing investment
+                          (selectedProject.marketingCampaign ||
+                            selectedProject.marketingData?.totalSpent) &&
+                          // Allow planning once the film is in marketing or beyond,
+                          // or explicitly flagged as ready for release
+                          (
+                            selectedProject.currentPhase === 'marketing' ||
+                            selectedProject.currentPhase === 'release' ||
+                            selectedProject.status === 'ready-for-release' ||
+                            selectedProject.readyForRelease
+                          )
+                        )
                       }
                     >
                       Plan Release


### PR DESCRIPTION
Overview:
- Adds pre-release episode count editing for the first season and ties it to production budgeting and episode generation.
- Gathers and applies marketing progress checks to gate release planning, ensuring planning isn’t possible without marketing momentum and not limited to a single episode.

What changed:
1) EpisodeTrackingSystem.tsx
- Introduced updateEpisodeCount(project, newTotal) to adjust the total number of episodes for the first season (pre-release).
  - Clamps total to 1-26 episodes.
  - Recomputes per-episode productionCost based on season budget and new total.
  - Keeps existing episodes up to the new total, updates episodeNumber, and creates new placeholder episodes if the season is extended.
  - If the season order is reduced below aired episodes, clamps season.episodesAired to the new total.
  - Updates the project with the new seasons and shows a toast: "Season Updated" with the new total.
- Exposes onUpdateEpisodeCount to EpisodeSetupPanel and wires a call from EpisodeSetupPanel when the input changes.

2) EpisodeSetupPanel.tsx
- Extends props to accept onUpdateEpisodeCount?: (newTotal: number) => void.
- Adds a UI block to display current season info and an input to adjust total episode count (Episode 1–26).
- The input uses onChange to call onUpdateEpisodeCount(next) when a valid number is entered.
- Keeps existing episode editing flow intact.

3) StudioMagnateGame.tsx
- Refines Plan Release button disabled logic to ensure release planning only happens with marketing progress and appropriate phase.
- New behavior:
  - The Plan Release button is disabled unless there is marketing progress (marketingCampaign or marketingData.totalSpent) and the project is in a phase where release planning is valid (marketing, release) or already flagged as ready for release (currentPhase 'marketing' | 'release' | status 'ready-for-release' | readyForRelease).
- This prevents planning a release when there is no marketing progression and enforces a more realistic workflow where marketing must be underway.

Why this solves the issue:
- Before, episodes and release planning could be limited to a single episode or blocked by missing marketing progress. These changes enable pre-release planning to edit the number of episodes and scale the season accordingly, while gating release planning behind marketing activity. This aligns with the goal of planning film releases more realistically and ensuring multiple episodes/slots can air rather than only a single episode.

Testing guidance:
- Open EpisodeTrackingSystem and navigate to EpisodeSetupPanel for the first season. Increase the total episode count and verify:
  - The season.totalEpisodes updates and is reflected in the UI.
  - Per-episode productionCost recalculates based on the new total.
  - New placeholder episodes are added with proper defaults when extending the season.
  - Reducing the total episode count clamps aired episodes as needed.
- Try setting the total to 1 and confirm multiple episodes are not created and the UI reflects the correct total.
- In StudioMagnateGame, ensure the Plan Release button is disabled when there is no marketing progress and enabled when marketing progress exists and the project is in an appropriate phase; verify that changing currentPhase or status affects the button state as described.


---

> This pull request was co-created with Cosine Genie

Original Task: [studio-dynasty-builder/ssatm3gm89w4](https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/ssatm3gm89w4)
Author: Evan Lewis
