### PR TITLE
Add persisted Industry Database (films, TV, actors, awards, studios) with UI panel and auto-sync

### DIFF
--- a/src/components/game/IndustryDatabasePanel.tsx
+++ b/src/components/game/IndustryDatabasePanel.tsx
@@ -1,0 +1,778 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { GameState, Genre } from '@/types/game';
+import type { AwardDbRecord, FilmDbRecord, IndustryDatabase, TalentDbRecord, TvShowDbRecord } from '@/types/industryDatabase';
+import { createEmptyIndustryDatabase, loadIndustryDatabase, saveIndustryDatabase, syncIndustryDatabase } from '@/utils/industryDatabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+interface IndustryDatabasePanelProps {
+  gameState: GameState;
+  slotId?: string;
+}
+
+const formatCurrency = (amount?: number): string => {
+  if (!amount || amount <= 0) return '$0';
+  if (amount >= 1_000_000_000) return `$${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(0)}K`;
+  return `$${Math.floor(amount)}`;
+};
+
+const formatNumber = (value?: number): string => {
+  if (!value || value <= 0) return '0';
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+  return `${Math.floor(value)}`;
+};
+
+const ALL_GENRES: Genre[] = [
+  'action',
+  'adventure',
+  'comedy',
+  'drama',
+  'horror',
+  'thriller',
+  'romance',
+  'sci-fi',
+  'fantasy',
+  'documentary',
+  'animation',
+  'musical',
+  'western',
+  'war',
+  'biography',
+  'crime',
+  'mystery',
+  'superhero',
+  'family',
+  'sports',
+  'historical',
+];
+
+export const IndustryDatabasePanel: React.FC<IndustryDatabasePanelProps> = ({ gameState, slotId }) => {
+  const slot = slotId || 'slot1';
+
+  const [db, setDb] = useState<IndustryDatabase>(() => {
+    if (typeof window === 'undefined') return createEmptyIndustryDatabase();
+    return loadIndustryDatabase(slot);
+  });
+
+  // Keep the persisted database synced with the current world state.
+  // We sync on week/year changes and on major catalog size changes to avoid doing
+  // a full scan on every small UI interaction.
+  useEffect(() => {
+    setDb((prev) => {
+      const synced = syncIndustryDatabase(prev, gameState);
+      if (synced !== prev) {
+        saveIndustryDatabase(slot, synced);
+      }
+      return synced;
+    });
+  }, [
+    slot,
+    gameState.currentWeek,
+    gameState.currentYear,
+    gameState.projects.length,
+    gameState.allReleases.length,
+    gameState.talent.length,
+    gameState.competitorStudios.length,
+    gameState.studio.awards?.length || 0,
+  ]);
+
+  const filmStudios = useMemo(() => {
+    const studios = new Set(db.films.map((f) => f.studioName).filter(Boolean));
+    return Array.from(studios).sort((a, b) => a.localeCompare(b));
+  }, [db.films]);
+
+  const tvStudios = useMemo(() => {
+    const studios = new Set(db.tvShows.map((t) => t.studioName).filter(Boolean));
+    return Array.from(studios).sort((a, b) => a.localeCompare(b));
+  }, [db.tvShows]);
+
+  const awardYears = useMemo(() => {
+    const years = new Set(db.awards.map((a) => a.year));
+    return Array.from(years).sort((a, b) => b - a);
+  }, [db.awards]);
+
+  // ===== Films tab state =====
+  const [filmSearch, setFilmSearch] = useState('');
+  const [filmGenre, setFilmGenre] = useState<string>('all');
+  const [filmStudio, setFilmStudio] = useState<string>('all');
+  const [filmYear, setFilmYear] = useState<string>('all');
+  const [minBoxOfficeM, setMinBoxOfficeM] = useState<string>('');
+  const [filmSort, setFilmSort] = useState<'boxOffice' | 'critics' | 'audience'>('boxOffice');
+
+  const filmYears = useMemo(() => {
+    const years = new Set(db.films.map((f) => f.releaseYear).filter(Boolean) as number[]);
+    return Array.from(years).sort((a, b) => b - a);
+  }, [db.films]);
+
+  const filteredFilms = useMemo(() => {
+    const minBo = minBoxOfficeM.trim() ? Number(minBoxOfficeM) * 1_000_000 : null;
+
+    const list = db.films.filter((f) => {
+      if (filmSearch.trim() && !f.title.toLowerCase().includes(filmSearch.trim().toLowerCase())) return false;
+      if (filmGenre !== 'all' && f.genre !== filmGenre) return false;
+      if (filmStudio !== 'all' && f.studioName !== filmStudio) return false;
+      if (filmYear !== 'all' && String(f.releaseYear || '') !== filmYear) return false;
+      if (minBo !== null && (f.boxOfficeTotal || 0) < minBo) return false;
+      return true;
+    });
+
+    const sorted = [...list].sort((a, b) => {
+      if (filmSort === 'critics') return (b.criticsScore || 0) - (a.criticsScore || 0);
+      if (filmSort === 'audience') return (b.audienceScore || 0) - (a.audienceScore || 0);
+      return (b.boxOfficeTotal || 0) - (a.boxOfficeTotal || 0);
+    });
+
+    return sorted;
+  }, [db.films, filmGenre, filmSearch, filmSort, filmStudio, filmYear, minBoxOfficeM]);
+
+  // ===== TV tab state =====
+  const [tvSearch, setTvSearch] = useState('');
+  const [tvGenre, setTvGenre] = useState<string>('all');
+  const [tvStudio, setTvStudio] = useState<string>('all');
+  const [tvYear, setTvYear] = useState<string>('all');
+  const [tvSort, setTvSort] = useState<'totalViews' | 'audienceScore' | 'criticsScore'>('totalViews');
+
+  const tvYears = useMemo(() => {
+    const years = new Set(db.tvShows.map((f) => f.releaseYear).filter(Boolean) as number[]);
+    return Array.from(years).sort((a, b) => b - a);
+  }, [db.tvShows]);
+
+  const filteredTv = useMemo(() => {
+    const list = db.tvShows.filter((t) => {
+      if (tvSearch.trim() && !t.title.toLowerCase().includes(tvSearch.trim().toLowerCase())) return false;
+      if (tvGenre !== 'all' && t.genre !== tvGenre) return false;
+      if (tvStudio !== 'all' && t.studioName !== tvStudio) return false;
+      if (tvYear !== 'all' && String(t.releaseYear || '') !== tvYear) return false;
+      return true;
+    });
+
+    return [...list].sort((a, b) => {
+      if (tvSort === 'criticsScore') return (b.criticsScore || 0) - (a.criticsScore || 0);
+      if (tvSort === 'audienceScore') return (b.audienceScore || 0) - (a.audienceScore || 0);
+      return (b.totalViews || 0) - (a.totalViews || 0);
+    });
+  }, [db.tvShows, tvGenre, tvSearch, tvSort, tvStudio, tvYear]);
+
+  // ===== Talent tab state =====
+  const [talentSearch, setTalentSearch] = useState('');
+  const [actorSort, setActorSort] = useState<'fame' | 'reputation' | 'marketValue'>('fame');
+  const [directorSort, setDirectorSort] = useState<'reputation' | 'marketValue'>('reputation');
+
+  const actors = useMemo(() => {
+    const list = db.talent
+      .filter((t) => t.type === 'actor')
+      .filter((t) => (talentSearch.trim() ? t.name.toLowerCase().includes(talentSearch.trim().toLowerCase()) : true));
+
+    return [...list].sort((a, b) => {
+      if (actorSort === 'marketValue') return (b.marketValue || 0) - (a.marketValue || 0);
+      if (actorSort === 'reputation') return (b.reputation || 0) - (a.reputation || 0);
+      return (b.fame || 0) - (a.fame || 0);
+    });
+  }, [actorSort, db.talent, talentSearch]);
+
+  const directors = useMemo(() => {
+    const list = db.talent
+      .filter((t) => t.type === 'director')
+      .filter((t) => (talentSearch.trim() ? t.name.toLowerCase().includes(talentSearch.trim().toLowerCase()) : true));
+
+    return [...list].sort((a, b) => {
+      if (directorSort === 'marketValue') return (b.marketValue || 0) - (a.marketValue || 0);
+      return (b.reputation || 0) - (a.reputation || 0);
+    });
+  }, [db.talent, directorSort, talentSearch]);
+
+  // ===== Awards tab state =====
+  const [awardYear, setAwardYear] = useState<string>('all');
+  const [awardType, setAwardType] = useState<'all' | 'studio' | 'talent'>('all');
+  const [awardCeremony, setAwardCeremony] = useState<string>('all');
+
+  const awardCeremonies = useMemo(() => {
+    const ceremonies = new Set(db.awards.map((a) => a.ceremony).filter(Boolean));
+    return Array.from(ceremonies).sort((a, b) => a.localeCompare(b));
+  }, [db.awards]);
+
+  const filteredAwards = useMemo(() => {
+    return db.awards
+      .filter((a) => (awardYear === 'all' ? true : String(a.year) === awardYear))
+      .filter((a) => (awardType === 'all' ? true : a.awardType === awardType))
+      .filter((a) => (awardCeremony === 'all' ? true : a.ceremony === awardCeremony))
+      .sort((a, b) => b.year - a.year);
+  }, [awardCeremony, awardType, awardYear, db.awards]);
+
+  // ===== Studios tab state =====
+  const studios = useMemo(() => {
+    const names = new Set<string>();
+    db.studios.forEach((s) => names.add(s.name));
+    db.films.forEach((f) => names.add(f.studioName));
+    db.tvShows.forEach((t) => names.add(t.studioName));
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [db.films, db.studios, db.tvShows]);
+
+  const [selectedStudio, setSelectedStudio] = useState<string>(() => studios[0] || gameState.studio.name);
+
+  useEffect(() => {
+    if (!selectedStudio && studios.length > 0) setSelectedStudio(studios[0]);
+  }, [selectedStudio, studios]);
+
+  const studioFilms = useMemo(() => {
+    return db.films
+      .filter((f) => f.studioName === selectedStudio)
+      .sort((a, b) => (b.releaseYear || 0) - (a.releaseYear || 0) || (b.boxOfficeTotal || 0) - (a.boxOfficeTotal || 0));
+  }, [db.films, selectedStudio]);
+
+  const studioTv = useMemo(() => {
+    return db.tvShows
+      .filter((t) => t.studioName === selectedStudio)
+      .sort((a, b) => (b.releaseYear || 0) - (a.releaseYear || 0) || (b.totalViews || 0) - (a.totalViews || 0));
+  }, [db.tvShows, selectedStudio]);
+
+  const studioTotals = useMemo(() => {
+    const totalBoxOffice = studioFilms.reduce((sum, f) => sum + (f.boxOfficeTotal || 0), 0);
+    const totalViews = studioTv.reduce((sum, t) => sum + (t.totalViews || 0), 0);
+    return { totalBoxOffice, totalViews };
+  }, [studioFilms, studioTv]);
+
+  const renderFilmsTable = (rows: FilmDbRecord[]) => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Title</TableHead>
+          <TableHead>Studio</TableHead>
+          <TableHead>Genre</TableHead>
+          <TableHead className="text-right">Box Office</TableHead>
+          <TableHead className="text-right">Budget</TableHead>
+          <TableHead className="text-right">Critics</TableHead>
+          <TableHead className="text-right">Audience</TableHead>
+          <TableHead>Release</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((f) => (
+          <TableRow key={f.id}>
+            <TableCell className="font-medium">{f.title}</TableCell>
+            <TableCell>{f.studioName}</TableCell>
+            <TableCell className="capitalize">{f.genre || 'unknown'}</TableCell>
+            <TableCell className="text-right">{formatCurrency(f.boxOfficeTotal)}</TableCell>
+            <TableCell className="text-right">{formatCurrency(f.budget)}</TableCell>
+            <TableCell className="text-right">{f.criticsScore ?? '—'}</TableCell>
+            <TableCell className="text-right">{f.audienceScore ?? '—'}</TableCell>
+            <TableCell>
+              {f.releaseYear ? `Y${f.releaseYear}` : '—'}
+              {f.releaseWeek ? ` W${f.releaseWeek}` : ''}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  const renderTvTable = (rows: TvShowDbRecord[]) => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Rank</TableHead>
+          <TableHead>Title</TableHead>
+          <TableHead>Studio</TableHead>
+          <TableHead>Genre</TableHead>
+          <TableHead className="text-right">Total Views</TableHead>
+          <TableHead className="text-right">Share</TableHead>
+          <TableHead className="text-right">Critics</TableHead>
+          <TableHead className="text-right">Audience</TableHead>
+          <TableHead>Release</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((t, idx) => (
+          <TableRow key={t.id}>
+            <TableCell>
+              <Badge variant="secondary">#{idx + 1}</Badge>
+            </TableCell>
+            <TableCell className="font-medium">{t.title}</TableCell>
+            <TableCell>{t.studioName}</TableCell>
+            <TableCell className="capitalize">{t.genre || 'unknown'}</TableCell>
+            <TableCell className="text-right">{formatNumber(t.totalViews)}</TableCell>
+            <TableCell className="text-right">{t.audienceShare != null ? `${t.audienceShare}%` : '—'}</TableCell>
+            <TableCell className="text-right">{t.criticsScore ?? '—'}</TableCell>
+            <TableCell className="text-right">{t.audienceScore ?? '—'}</TableCell>
+            <TableCell>
+              {t.releaseYear ? `Y${t.releaseYear}` : '—'}
+              {t.releaseWeek ? ` W${t.releaseWeek}` : ''}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  const renderTalentTable = (rows: TalentDbRecord[], rankLabel: 'Fame' | 'Rep') => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Rank</TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead className="text-right">{rankLabel}</TableHead>
+          <TableHead className="text-right">Market Value</TableHead>
+          <TableHead className="text-right">Awards</TableHead>
+          <TableHead className="text-right">Credits</TableHead>
+          <TableHead>Genres</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((t, idx) => (
+          <TableRow key={t.id}>
+            <TableCell>
+              <Badge variant="secondary">#{idx + 1}</Badge>
+            </TableCell>
+            <TableCell className="font-medium">{t.name}</TableCell>
+            <TableCell className="text-right">{rankLabel === 'Fame' ? (t.fame ?? '—') : (t.reputation ?? '—')}</TableCell>
+            <TableCell className="text-right">{t.marketValue ? formatCurrency(t.marketValue) : '—'}</TableCell>
+            <TableCell className="text-right">{t.awardsCount ?? 0}</TableCell>
+            <TableCell className="text-right">{t.filmographyCount ?? 0}</TableCell>
+            <TableCell>
+              <div className="flex flex-wrap gap-1">
+                {(t.genres || []).slice(0, 3).map((g) => (
+                  <Badge key={g} variant="outline" className="text-xs capitalize">
+                    {g}
+                  </Badge>
+                ))}
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  const renderAwardsTable = (rows: AwardDbRecord[]) => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Year</TableHead>
+          <TableHead>Ceremony</TableHead>
+          <TableHead>Category</TableHead>
+          <TableHead>Project</TableHead>
+          <TableHead>Talent</TableHead>
+          <TableHead>Studio</TableHead>
+          <TableHead className="text-right">Prestige</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((a) => (
+          <TableRow key={a.id}>
+            <TableCell>Y{a.year}</TableCell>
+            <TableCell>{a.ceremony}</TableCell>
+            <TableCell>{a.category}</TableCell>
+            <TableCell>{a.projectTitle || a.projectId}</TableCell>
+            <TableCell>{a.talentName || (a.awardType === 'studio' ? '—' : a.talentId || '—')}</TableCell>
+            <TableCell>{a.studioName}</TableCell>
+            <TableCell className="text-right">{a.prestige}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card className="card-premium">
+        <CardHeader>
+          <CardTitle>Industry Databases (Persisted)</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Browsable databases for released films, TV shows, talent, awards, and studios. This catalog is stored in this browser and continues to update as the simulation runs.
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="films" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-6">
+          <TabsTrigger value="films">Films</TabsTrigger>
+          <TabsTrigger value="tv">TV Shows</TabsTrigger>
+          <TabsTrigger value="actors">Actors</TabsTrigger>
+          <TabsTrigger value="directors">Directors</TabsTrigger>
+          <TabsTrigger value="awards">Awards</TabsTrigger>
+          <TabsTrigger value="studios">Studios</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="films" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>Films Database</span>
+                <Badge variant="outline">{filteredFilms.length} results</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <Input value={filmSearch} onChange={(e) => setFilmSearch(e.target.value)} placeholder="Search title..." />
+
+                <Select value={filmGenre} onValueChange={setFilmGenre}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Genre" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All genres</SelectItem>
+                    {ALL_GENRES.map((g) => (
+                      <SelectItem key={g} value={g}>
+                        {g}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={filmStudio} onValueChange={setFilmStudio}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Studio" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All studios</SelectItem>
+                    {filmStudios.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={filmYear} onValueChange={setFilmYear}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Year" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All years</SelectItem>
+                    {filmYears.map((y) => (
+                      <SelectItem key={y} value={String(y)}>
+                        {y}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Input
+                  value={minBoxOfficeM}
+                  onChange={(e) => setMinBoxOfficeM(e.target.value)}
+                  placeholder="Min box office ($M)"
+                  inputMode="decimal"
+                />
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="text-sm text-muted-foreground">Sort by</div>
+                <Select value={filmSort} onValueChange={(v) => {
+                  if (v === 'boxOffice' || v === 'critics' || v === 'audience') setFilmSort(v);
+                }}>
+                  <SelectTrigger className="w-[220px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="boxOffice">Box Office</SelectItem>
+                    <SelectItem value="critics">Critics Score</SelectItem>
+                    <SelectItem value="audience">Audience Score</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <ScrollArea className="h-[520px] rounded border">
+                {filteredFilms.length === 0 ? (
+                  <div className="p-6 text-center text-muted-foreground">No films match your filters yet.</div>
+                ) : (
+                  <div className="p-2">{renderFilmsTable(filteredFilms)}</div>
+                )}
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="tv" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>TV Shows Database + Ratings Ranking</span>
+                <Badge variant="outline">{filteredTv.length} results</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <Input value={tvSearch} onChange={(e) => setTvSearch(e.target.value)} placeholder="Search title..." />
+
+                <Select value={tvGenre} onValueChange={setTvGenre}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Genre" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All genres</SelectItem>
+                    {ALL_GENRES.map((g) => (
+                      <SelectItem key={g} value={g}>
+                        {g}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={tvStudio} onValueChange={setTvStudio}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Studio" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All studios</SelectItem>
+                    {tvStudios.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={tvYear} onValueChange={setTvYear}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Year" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All years</SelectItem>
+                    {tvYears.map((y) => (
+                      <SelectItem key={y} value={String(y)}>
+                        {y}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={tvSort} onValueChange={(v) => {
+                  if (v === 'totalViews' || v === 'audienceScore' || v === 'criticsScore') setTvSort(v);
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="totalViews">Total Views (Ranking)</SelectItem>
+                    <SelectItem value="audienceScore">Audience Score</SelectItem>
+                    <SelectItem value="criticsScore">Critics Score</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <ScrollArea className="h-[520px] rounded border">
+                {filteredTv.length === 0 ? (
+                  <div className="p-6 text-center text-muted-foreground">No TV shows match your filters yet.</div>
+                ) : (
+                  <div className="p-2">{renderTvTable(filteredTv)}</div>
+                )}
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="actors" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>Actors Database + Fame Ranking</span>
+                <Badge variant="outline">{actors.length} results</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Input value={talentSearch} onChange={(e) => setTalentSearch(e.target.value)} placeholder="Search talent..." />
+                <Select value={actorSort} onValueChange={(v) => {
+                  if (v === 'fame' || v === 'reputation' || v === 'marketValue') setActorSort(v);
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fame">Fame</SelectItem>
+                    <SelectItem value="reputation">Reputation</SelectItem>
+                    <SelectItem value="marketValue">Market Value</SelectItem>
+                  </SelectContent>
+                </Select>
+                <div className="text-sm text-muted-foreground flex items-center">
+                  Fame is persisted from the game talent pool (fallbacks to reputation if needed).
+                </div>
+              </div>
+
+              <ScrollArea className="h-[520px] rounded border">
+                {actors.length === 0 ? (
+                  <div className="p-6 text-center text-muted-foreground">No actors available.</div>
+                ) : (
+                  <div className="p-2">{renderTalentTable(actors, 'Fame')}</div>
+                )}
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="directors" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>Directors Database</span>
+                <Badge variant="outline">{directors.length} results</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Input value={talentSearch} onChange={(e) => setTalentSearch(e.target.value)} placeholder="Search talent..." />
+                <Select value={directorSort} onValueChange={(v) => {
+                  if (v === 'reputation' || v === 'marketValue') setDirectorSort(v);
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="reputation">Reputation</SelectItem>
+                    <SelectItem value="marketValue">Market Value</SelectItem>
+                  </SelectContent>
+                </Select>
+                <div className="text-sm text-muted-foreground flex items-center">Includes all directors in the persistent talent catalog.</div>
+              </div>
+
+              <ScrollArea className="h-[520px] rounded border">
+                {directors.length === 0 ? (
+                  <div className="p-6 text-center text-muted-foreground">No directors available.</div>
+                ) : (
+                  <div className="p-2">{renderTalentTable(directors, 'Rep')}</div>
+                )}
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="awards" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>Awards Database (Filter by Year)</span>
+                <Badge variant="outline">{filteredAwards.length} results</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+                <Select value={awardYear} onValueChange={setAwardYear}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Year" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All years</SelectItem>
+                    {awardYears.map((y) => (
+                      <SelectItem key={y} value={String(y)}>
+                        {y}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={awardCeremony} onValueChange={setAwardCeremony}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Ceremony" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All ceremonies</SelectItem>
+                    {awardCeremonies.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {c}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select value={awardType} onValueChange={(v) => {
+                  if (v === 'all' || v === 'studio' || v === 'talent') setAwardType(v);
+                }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All awards</SelectItem>
+                    <SelectItem value="studio">Studio awards</SelectItem>
+                    <SelectItem value="talent">Talent awards</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <div className="text-sm text-muted-foreground flex items-center">
+                  Awards are captured from both studio wins and talent wins.
+                </div>
+              </div>
+
+              <ScrollArea className="h-[520px] rounded border">
+                {filteredAwards.length === 0 ? (
+                  <div className="p-6 text-center text-muted-foreground">No awards match your filters.</div>
+                ) : (
+                  <div className="p-2">{renderAwardsTable(filteredAwards)}</div>
+                )}
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="studios" className="space-y-4">
+          <Card className="card-premium">
+            <CardHeader>
+              <CardTitle>Studios + Released Work</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Select value={selectedStudio} onValueChange={setSelectedStudio}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select studio" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {studios.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <div className="p-3 rounded border bg-muted/20">
+                  <div className="text-sm text-muted-foreground">Total Box Office</div>
+                  <div className="text-lg font-semibold">{formatCurrency(studioTotals.totalBoxOffice)}</div>
+                </div>
+
+                <div className="p-3 rounded border bg-muted/20">
+                  <div className="text-sm text-muted-foreground">Total TV Views</div>
+                  <div className="text-lg font-semibold">{formatNumber(studioTotals.totalViews)}</div>
+                </div>
+              </div>
+
+              <Tabs defaultValue="films" className="space-y-3">
+                <TabsList>
+                  <TabsTrigger value="films">Films ({studioFilms.length})</TabsTrigger>
+                  <TabsTrigger value="tv">TV Shows ({studioTv.length})</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="films">
+                  <ScrollArea className="h-[420px] rounded border">
+                    {studioFilms.length === 0 ? (
+                      <div className="p-6 text-center text-muted-foreground">No films recorded for this studio yet.</div>
+                    ) : (
+                      <div className="p-2">{renderFilmsTable(studioFilms)}</div>
+                    )}
+                  </ScrollArea>
+                </TabsContent>
+
+                <TabsContent value="tv">
+                  <ScrollArea className="h-[420px] rounded border">
+                    {studioTv.length === 0 ? (
+                      <div className="p-6 text-center text-muted-foreground">No TV shows recorded for this studio yet.</div>
+                    ) : (
+                      <div className="p-2">{renderTvTable(studioTv)}</div>
+                    )}
+                  </ScrollArea>
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -99,7 +99,9 @@ import { CrisisManagement } from './CrisisManagement';
 import { MediaRelationships } from './MediaRelationships';
 import { SystemIntegration } from './SystemIntegration';
 import { saveGame } from '@/utils/saveLoad';
+import { syncAndPersistIndustryDatabase } from '@/utils/industryDatabase';
 import { DebugControlPanel } from './DebugControlPanel';
+import { IndustryDatabasePanel } from './IndustryDatabasePanel';
 
 // Ensure AI films have credited talent so awards/filmographies have real people to reference
 function attachBasicCastForAI(project: Project, talentPool: TalentPerson[]): Project {
@@ -563,7 +565,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
     'dashboard' | 'scripts' | 'casting' | 'talent' | 'franchise' | 'media' |
     'production' | 'marketing' | 'distribution' | 'finance' |
     'awards' | 'market' | 'topfilms' | 'stats' | 'reputation' | 'loans' |
-    'competition' | 'television' | 'tv-tests'
+    'competition' | 'television' | 'tv-tests' | 'database'
   >(((initialPhase === 'financials' ? 'finance' : initialPhase) as any) || 'dashboard');
 
   const achievements = useAchievements(gameState, initialUnlockedAchievements);
@@ -571,6 +573,13 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
   const [selectedFranchise, setSelectedFranchise] = useState<string | null>(null);
   const [selectedPublicDomain, setSelectedPublicDomain] = useState<string | null>(null);
   const [filmReleaseProject, setFilmReleaseProject] = useState<Project | null>(null);
+
+  // Persist a long-lived, cross-session industry catalog (films/TV/talent/awards/studios).
+  // This is separate from the save-game snapshot and continues to accrue even if the in-memory
+  // simulation prunes older releases for performance.
+  useEffect(() => {
+    syncAndPersistIndustryDatabase('slot1', gameState);
+  }, [gameState.currentWeek, gameState.currentYear]);
   
   // First week box office modal state
   const [firstWeekModalProject, setFirstWeekModalProject] = useState<Project | null>(null);
@@ -2269,7 +2278,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
                 <Button
                   variant="ghost"
                   className={`rounded-none border-b-2 px-4 py-4 font-medium transition-all duration-300 border-transparent hover:border-primary/40 hover:bg-primary/5 btn-ghost-premium ${
-                     ['franchise', 'media', 'talent', 'awards', 'reputation'].includes(currentPhase)
+                     ['franchise', 'media', 'talent', 'database', 'awards', 'reputation'].includes(currentPhase)
                        ? 'border-primary bg-gradient-to-t from-primary/20 to-primary/10 text-primary shadow-lg' 
                        : ''
                    }`}
@@ -2291,6 +2300,10 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
                  <DropdownMenuItem onClick={() => handlePhaseChange('talent')}>
                    <CastingIcon className="mr-2" size={16} />
                    Talent Management
+                 </DropdownMenuItem>
+                 <DropdownMenuItem onClick={() => handlePhaseChange('database')}>
+                   <BarChartIcon className="mr-2" size={16} />
+                   Industry Databases
                  </DropdownMenuItem>
                  <DropdownMenuItem onClick={() => handlePhaseChange('television')}>
                    <BarChartIcon className="mr-2" size={16} />
@@ -2832,7 +2845,10 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
             </Tabs>
           </div>
         )}
-        
+
+        {currentPhase === 'database' && (
+          <IndustryDatabasePanel gameState={gameState} slotId="slot1" />
+        )}
         
         {currentPhase === 'production' && (
           <ProductionManagement 

--- a/src/types/industryDatabase.ts
+++ b/src/types/industryDatabase.ts
@@ -1,0 +1,77 @@
+import type { Genre } from './game';
+
+export type IndustryTalentType = 'actor' | 'director';
+
+export interface FilmDbRecord {
+  id: string;
+  title: string;
+  studioName: string;
+  releaseWeek?: number;
+  releaseYear?: number;
+  genre?: Genre;
+  budget?: number;
+  boxOfficeTotal?: number;
+  criticsScore?: number;
+  audienceScore?: number;
+}
+
+export interface TvShowDbRecord {
+  id: string;
+  title: string;
+  studioName: string;
+  releaseWeek?: number;
+  releaseYear?: number;
+  genre?: Genre;
+  budget?: number;
+  totalViews?: number;
+  audienceShare?: number;
+  criticsScore?: number;
+  audienceScore?: number;
+}
+
+export interface TalentDbRecord {
+  id: string;
+  name: string;
+  type: IndustryTalentType;
+  age?: number;
+  fame?: number;
+  reputation?: number;
+  marketValue?: number;
+  awardsCount?: number;
+  filmographyCount?: number;
+  genres?: Genre[];
+}
+
+export type AwardRecordType = 'studio' | 'talent';
+
+export interface AwardDbRecord {
+  id: string;
+  awardType: AwardRecordType;
+  year: number;
+  ceremony: string;
+  category: string;
+  prestige: number;
+  studioName: string;
+  projectId: string;
+  projectTitle?: string;
+  talentId?: string;
+  talentName?: string;
+}
+
+export interface StudioDbRecord {
+  id: string;
+  name: string;
+  founded?: number;
+  reputation?: number;
+  specialties?: Genre[];
+}
+
+export interface IndustryDatabase {
+  version: 1;
+  updatedAt: string;
+  films: FilmDbRecord[];
+  tvShows: TvShowDbRecord[];
+  talent: TalentDbRecord[];
+  awards: AwardDbRecord[];
+  studios: StudioDbRecord[];
+}

--- a/src/utils/industryDatabase.ts
+++ b/src/utils/industryDatabase.ts
@@ -1,0 +1,293 @@
+import type { GameState, Project, TalentPerson } from '@/types/game';
+import type {
+  AwardDbRecord,
+  FilmDbRecord,
+  IndustryDatabase,
+  StudioDbRecord,
+  TalentDbRecord,
+  TvShowDbRecord,
+} from '@/types/industryDatabase';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+const DB_VERSION = 1 as const;
+
+const keyForSlot = (slotId: string) => `studio-magnate-industry-db-${DB_VERSION}-${slotId}`;
+
+export function createEmptyIndustryDatabase(): IndustryDatabase {
+  return {
+    version: DB_VERSION,
+    updatedAt: new Date(0).toISOString(),
+    films: [],
+    tvShows: [],
+    talent: [],
+    awards: [],
+    studios: [],
+  };
+}
+
+export function loadIndustryDatabase(slotId: string, storage?: StorageLike): IndustryDatabase {
+  const store: StorageLike | undefined = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!store) return createEmptyIndustryDatabase();
+
+  try {
+    const raw = store.getItem(keyForSlot(slotId));
+    if (!raw) return createEmptyIndustryDatabase();
+
+    const parsed = JSON.parse(raw) as IndustryDatabase;
+    if (!parsed || parsed.version !== DB_VERSION) return createEmptyIndustryDatabase();
+
+    return parsed;
+  } catch {
+    return createEmptyIndustryDatabase();
+  }
+}
+
+export function saveIndustryDatabase(slotId: string, db: IndustryDatabase, storage?: StorageLike): void {
+  const store: StorageLike | undefined = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!store) return;
+
+  try {
+    store.setItem(keyForSlot(slotId), JSON.stringify(db));
+  } catch (e) {
+    console.warn('Failed to persist industry database', e);
+  }
+}
+
+function getProjectStudioName(gameState: GameState, project: Project): string {
+  if (project.studioName && project.studioName.trim()) return project.studioName;
+  return gameState.studio.name;
+}
+
+function upsertById<T extends { id: string }>(list: T[], record: T): { list: T[]; changed: boolean } {
+  const idx = list.findIndex((x) => x.id === record.id);
+  if (idx === -1) {
+    return { list: [...list, record], changed: true };
+  }
+
+  const prev = list[idx];
+  const same = JSON.stringify(prev) === JSON.stringify(record);
+  if (same) return { list, changed: false };
+
+  const next = [...list];
+  next[idx] = record;
+  return { list: next, changed: true };
+}
+
+function buildFilmRecord(gameState: GameState, project: Project): FilmDbRecord {
+  return {
+    id: project.id,
+    title: project.title,
+    studioName: getProjectStudioName(gameState, project),
+    releaseWeek: project.releaseWeek,
+    releaseYear: project.releaseYear,
+    genre: project.script?.genre,
+    budget: project.budget?.total,
+    boxOfficeTotal: project.metrics?.boxOfficeTotal,
+    criticsScore: project.metrics?.criticsScore,
+    audienceScore: project.metrics?.audienceScore,
+  };
+}
+
+function buildTvShowRecord(gameState: GameState, project: Project): TvShowDbRecord {
+  return {
+    id: project.id,
+    title: project.title,
+    studioName: getProjectStudioName(gameState, project),
+    releaseWeek: project.releaseWeek,
+    releaseYear: project.releaseYear,
+    genre: project.script?.genre,
+    budget: project.budget?.total,
+    totalViews: project.metrics?.streaming?.totalViews,
+    audienceShare: project.metrics?.streaming?.audienceShare,
+    criticsScore: project.metrics?.criticsScore,
+    audienceScore: project.metrics?.audienceScore,
+  };
+}
+
+function computeFame(t: TalentPerson): number {
+  const rep = Math.round(t.reputation || 0);
+  return Math.max(0, Math.min(100, t.fame ?? rep));
+}
+
+function buildTalentRecord(t: TalentPerson): TalentDbRecord {
+  const awardsCount = (t.awards || []).length;
+  const filmographyCount = (t.filmography || []).length;
+
+  return {
+    id: t.id,
+    name: t.name,
+    type: t.type === 'director' ? 'director' : 'actor',
+    age: t.age,
+    fame: t.type === 'actor' ? computeFame(t) : undefined,
+    reputation: Math.round(t.reputation || 0),
+    marketValue: t.marketValue,
+    awardsCount,
+    filmographyCount,
+    genres: t.genres,
+  };
+}
+
+function buildStudioRecord(gameState: GameState, studioId: string, name: string): StudioDbRecord {
+  if (studioId === gameState.studio.id) {
+    return {
+      id: studioId,
+      name: gameState.studio.name,
+      founded: gameState.studio.founded,
+      reputation: gameState.studio.reputation,
+      specialties: gameState.studio.specialties,
+    };
+  }
+
+  const st = gameState.competitorStudios.find((s) => s.id === studioId || s.name === name);
+  return {
+    id: studioId,
+    name,
+    founded: st?.founded,
+    reputation: st?.reputation,
+    specialties: st?.specialties,
+  };
+}
+
+function buildAwardRecords(gameState: GameState): AwardDbRecord[] {
+  const byProject = new Map<string, Project>();
+
+  const allProjects: Project[] = [
+    ...gameState.projects,
+    ...gameState.allReleases.filter((r): r is Project => 'script' in r),
+  ];
+
+  allProjects.forEach((p) => byProject.set(p.id, p));
+
+  const studioAwards: AwardDbRecord[] = (gameState.studio.awards || []).map((a) => {
+    const project = byProject.get(a.projectId);
+    const studioName = project ? getProjectStudioName(gameState, project) : gameState.studio.name;
+
+    return {
+      id: a.id,
+      awardType: 'studio',
+      year: a.year,
+      ceremony: a.ceremony,
+      category: a.category,
+      prestige: a.prestige,
+      studioName,
+      projectId: a.projectId,
+      projectTitle: project?.title,
+    };
+  });
+
+  const talentAwards: AwardDbRecord[] = gameState.talent
+    .flatMap((t) => (t.awards || []).map((a) => ({ talent: t, award: a })))
+    .map(({ talent, award }) => {
+      const project = byProject.get(award.projectId);
+      const studioName = project ? getProjectStudioName(gameState, project) : gameState.studio.name;
+
+      return {
+        id: award.id,
+        awardType: 'talent',
+        year: award.year,
+        ceremony: award.ceremony,
+        category: award.category,
+        prestige: award.prestige,
+        studioName,
+        projectId: award.projectId,
+        projectTitle: project?.title,
+        talentId: talent.id,
+        talentName: talent.name,
+      };
+    });
+
+  return [...studioAwards, ...talentAwards];
+}
+
+export function syncIndustryDatabase(db: IndustryDatabase, gameState: GameState): IndustryDatabase {
+  let changed = false;
+
+  let nextFilms = db.films;
+  let nextTv = db.tvShows;
+  let nextTalent = db.talent;
+  let nextAwards = db.awards;
+  let nextStudios = db.studios;
+
+  const allProjects: Project[] = [
+    ...gameState.projects,
+    ...gameState.allReleases.filter((r): r is Project => 'script' in r),
+  ];
+
+  // Always include core studio rows (even if they haven't released yet).
+  {
+    const { list, changed: sc } = upsertById(nextStudios, buildStudioRecord(gameState, gameState.studio.id, gameState.studio.name));
+    nextStudios = list;
+    changed = changed || sc;
+
+    for (const st of gameState.competitorStudios) {
+      const { list: l2, changed: c2 } = upsertById(nextStudios, buildStudioRecord(gameState, st.id, st.name));
+      nextStudios = l2;
+      changed = changed || c2;
+    }
+  }
+
+  // Released films + TV shows
+  for (const p of allProjects) {
+    const isReleased = p.status === 'released' || p.status === 'distribution' || p.status === 'archived';
+    if (!isReleased) continue;
+
+    const isTv = p.type === 'series' || p.type === 'limited-series';
+
+    if (isTv) {
+      const { list, changed: c } = upsertById(nextTv, buildTvShowRecord(gameState, p));
+      nextTv = list;
+      changed = changed || c;
+    } else {
+      const { list, changed: c } = upsertById(nextFilms, buildFilmRecord(gameState, p));
+      nextFilms = list;
+      changed = changed || c;
+    }
+
+    const stName = getProjectStudioName(gameState, p);
+    const studioId = stName === gameState.studio.name ? gameState.studio.id : `studio:${stName}`;
+    const { list: studiosList, changed: sc } = upsertById(nextStudios, buildStudioRecord(gameState, studioId, stName));
+    nextStudios = studiosList;
+    changed = changed || sc;
+  }
+
+  // Talent (actors + directors)
+  for (const t of gameState.talent) {
+    if (t.type !== 'actor' && t.type !== 'director') continue;
+    const { list, changed: c } = upsertById(nextTalent, buildTalentRecord(t));
+    nextTalent = list;
+    changed = changed || c;
+  }
+
+  // Awards
+  for (const award of buildAwardRecords(gameState)) {
+    const { list, changed: c } = upsertById(nextAwards, award);
+    nextAwards = list;
+    changed = changed || c;
+  }
+
+  if (!changed) return db;
+
+  return {
+    version: DB_VERSION,
+    updatedAt: new Date().toISOString(),
+    films: nextFilms,
+    tvShows: nextTv,
+    talent: nextTalent,
+    awards: nextAwards,
+    studios: nextStudios,
+  };
+}
+
+export function syncAndPersistIndustryDatabase(slotId: string, gameState: GameState): IndustryDatabase {
+  const existing = loadIndustryDatabase(slotId);
+  const synced = syncIndustryDatabase(existing, gameState);
+  if (synced !== existing) {
+    saveIndustryDatabase(slotId, synced);
+  }
+  return synced;
+}

--- a/tests/industryDatabase.test.ts
+++ b/tests/industryDatabase.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState } from '@/types/game';
+import { createEmptyIndustryDatabase, syncIndustryDatabase } from '@/utils/industryDatabase';
+
+describe('industry database sync', () => {
+  it('captures released films, tv shows, talent, and awards into a persisted catalog', () => {
+    const gameState = {
+      studio: {
+        id: 'player-studio',
+        name: 'Player Studio',
+        reputation: 55,
+        budget: 0,
+        founded: 2020,
+        specialties: ['drama'],
+        awards: [
+          {
+            id: 'sa-1',
+            projectId: 'film-1',
+            category: 'Best Picture',
+            ceremony: 'Academy Awards',
+            year: 2024,
+            prestige: 10,
+            reputationBoost: 5,
+          },
+        ],
+      },
+      competitorStudios: [],
+      currentWeek: 10,
+      currentYear: 2024,
+      projects: [
+        {
+          id: 'film-1',
+          title: 'Test Film',
+          type: 'feature',
+          status: 'released',
+          releaseWeek: 8,
+          releaseYear: 2024,
+          studioName: 'Player Studio',
+          script: { genre: 'action' },
+          budget: { total: 50_000_000 },
+          metrics: { boxOfficeTotal: 120_000_000, criticsScore: 80, audienceScore: 75 },
+        },
+        {
+          id: 'tv-1',
+          title: 'Test Show',
+          type: 'series',
+          status: 'released',
+          releaseWeek: 7,
+          releaseYear: 2024,
+          studioName: 'Player Studio',
+          script: { genre: 'drama' },
+          budget: { total: 80_000_000 },
+          metrics: {
+            criticsScore: 70,
+            audienceScore: 72,
+            streaming: { totalViews: 5_000_000, audienceShare: 12 },
+          },
+        },
+      ],
+      allReleases: [],
+      talent: [
+        {
+          id: 'actor-1',
+          name: 'A. Actor',
+          type: 'actor',
+          age: 30,
+          reputation: 60,
+          fame: 78,
+          marketValue: 10_000_000,
+          genres: ['action', 'drama'],
+          contractStatus: 'available',
+          availability: { start: new Date(), end: new Date() },
+          awards: [
+            {
+              id: 'ta-1',
+              talentId: 'actor-1',
+              projectId: 'film-1',
+              category: 'Best Actor',
+              ceremony: 'Academy Awards',
+              year: 2024,
+              prestige: 9,
+              reputationBoost: 3,
+            },
+          ],
+          filmography: [{ projectId: 'film-1', title: 'Test Film', role: 'Lead Actor', year: 2024, boxOffice: 120_000_000 }],
+        },
+        {
+          id: 'dir-1',
+          name: 'D. Director',
+          type: 'director',
+          age: 44,
+          reputation: 67,
+          marketValue: 8_000_000,
+          genres: ['drama'],
+          contractStatus: 'available',
+          availability: { start: new Date(), end: new Date() },
+          awards: [],
+          filmography: [],
+        },
+      ],
+      // Remaining GameState fields not used by sync
+      scripts: [],
+      marketConditions: {},
+      eventQueue: [],
+      boxOfficeHistory: [],
+      awardsCalendar: [],
+      industryTrends: [],
+      topFilmsHistory: [],
+      franchises: [],
+      publicDomainIPs: [],
+    };
+
+    const db0 = createEmptyIndustryDatabase();
+    const db1 = syncIndustryDatabase(db0, gameState as unknown as GameState);
+
+    expect(db1.films).toHaveLength(1);
+    expect(db1.films[0]).toMatchObject({
+      id: 'film-1',
+      title: 'Test Film',
+      studioName: 'Player Studio',
+      genre: 'action',
+      boxOfficeTotal: 120_000_000,
+    });
+
+    expect(db1.tvShows).toHaveLength(1);
+    expect(db1.tvShows[0]).toMatchObject({
+      id: 'tv-1',
+      title: 'Test Show',
+      totalViews: 5_000_000,
+    });
+
+    const actor = db1.talent.find((t) => t.id === 'actor-1');
+    expect(actor).toBeTruthy();
+    expect(actor).toMatchObject({ type: 'actor', fame: 78, awardsCount: 1, filmographyCount: 1 });
+
+    const director = db1.talent.find((t) => t.id === 'dir-1');
+    expect(director).toBeTruthy();
+    expect(director).toMatchObject({ type: 'director', reputation: 67 });
+
+    expect(db1.awards).toHaveLength(2);
+    expect(db1.awards.map((a) => a.year)).toEqual([2024, 2024]);
+  });
+
+  it('updates existing film records as metrics change', () => {
+    const gameState = {
+      studio: { id: 'player-studio', name: 'Player Studio', reputation: 50, budget: 0, founded: 2020, specialties: [] },
+      competitorStudios: [],
+      currentWeek: 12,
+      currentYear: 2024,
+      projects: [
+        {
+          id: 'film-1',
+          title: 'Test Film',
+          type: 'feature',
+          status: 'released',
+          releaseWeek: 8,
+          releaseYear: 2024,
+          studioName: 'Player Studio',
+          script: { genre: 'action' },
+          budget: { total: 50_000_000 },
+          metrics: { boxOfficeTotal: 120_000_000, criticsScore: 80, audienceScore: 75 },
+        },
+      ],
+      allReleases: [],
+      talent: [],
+      scripts: [],
+      marketConditions: {},
+      eventQueue: [],
+      boxOfficeHistory: [],
+      awardsCalendar: [],
+      industryTrends: [],
+      topFilmsHistory: [],
+      franchises: [],
+      publicDomainIPs: [],
+    };
+
+    const db1 = syncIndustryDatabase(createEmptyIndustryDatabase(), gameState as unknown as GameState);
+    expect(db1.films[0].boxOfficeTotal).toBe(120_000_000);
+
+    const gameState2 = {
+      ...gameState,
+      projects: [
+        {
+          ...gameState.projects[0],
+          metrics: {
+            ...gameState.projects[0].metrics,
+            boxOfficeTotal: 250_000_000,
+          },
+        },
+      ],
+    };
+
+    const db2 = syncIndustryDatabase(db1, gameState2 as unknown as GameState);
+
+    expect(db2.films[0].boxOfficeTotal).toBe(250_000_000);
+  });
+});


### PR DESCRIPTION
This PR introduces a new persisted Industry Database that tracks films, TV shows, talent, awards, and studios across sessions, plus a UI panel to view and filter the data.

What’s included:
- Industry database model and persistence
  - Added types for FilmDbRecord, TvShowDbRecord, TalentDbRecord, AwardDbRecord, StudioDbRecord, and IndustryDatabase.
  - Implemented a browser-local persistence layer with loadIndustryDatabase, saveIndustryDatabase, and a slot-based key. Data is versioned and can be loaded across sessions.
  - syncIndustryDatabase builds up a catalog from the game state (released projects, talent, and awards) and upserts records so the catalog stays in sync with the simulation.

- UI: IndustryDatabasePanel (src/components/game/IndustryDatabasePanel.tsx)
  - Tabbed interface with: Films, TV Shows, Actors, Directors, Awards, Studios.
  - Each tab includes filtering controls (search, genre, studio, year, min box office, etc.) and ranking/sorting options.
  - Films/TV tables render key metrics with currency/number formatting. Studios tab lets you view per-studio released work (films and TV) and quick totals.
  - Studio view aggregates total box office and total views for the selected studio and shows per-film/per-show data.

- Game integration
  - The StudioMagnateGame now persists the industry catalog by syncing and persisting on week/year changes via syncAndPersistIndustryDatabase(slotId, gameState).
  - A new menu entry (Industry Databases) is added to the database phase, routing players to the IndustryDatabasePanel. The phase label updates include the new database option.
  - The IndustryDatabasePanel uses slotId (default slot1) to support multiple catalogs if needed.

- Tests
  - Added tests (tests/industryDatabase.test.ts) to verify:
    - The catalog captures released films, TV shows, talent, and awards from a sample game state.
    - Updates to film metrics propagate into the persisted database (e.g., boxOfficeTotal updates).

Why this solves the task:
- Provides saved and persisted databases for films, actors, awards filtered by year, TV shows with rankings, and directors, plus a fame/market value view for talent.
- Allows easy viewing of other studios and their released work via the Studios tab and per-studio filtered lists.
- Keeps the catalog in sync with the ongoing game state and persists across sessions without relying on transient in-memory state.

Notes:
- The UI is designed to be non-intrusive and uses existing UI components (Card, Tabs, Select, Input, Table, etc.).
- The persistence is slot-based to support multiple catalogs in the future. Currently uses slot1 by default.
- The tests focus on core syncing behavior to ensure released work and talent/awards are captured correctly and that metric updates propagate.


https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/1uyy3nl2ncwu
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/23
Author: Evan Lewis