### PR TITLE
Add modding framework and patch-driven overrides (Providers, Franchise, Roles, and UI)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,10 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unused-expressions": [
+        "error",
+        { allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true },
+      ],
     },
   }
 );

--- a/src/components/game/IndustryDatabasePanel.tsx
+++ b/src/components/game/IndustryDatabasePanel.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ModsPanel } from './ModsPanel';
 
 interface IndustryDatabasePanelProps {
   gameState: GameState;
@@ -393,13 +394,14 @@ export const IndustryDatabasePanel: React.FC<IndustryDatabasePanelProps> = ({ ga
       </Card>
 
       <Tabs defaultValue="films" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-6">
+        <TabsList className="grid w-full grid-cols-7">
           <TabsTrigger value="films">Films</TabsTrigger>
           <TabsTrigger value="tv">TV Shows</TabsTrigger>
           <TabsTrigger value="actors">Actors</TabsTrigger>
           <TabsTrigger value="directors">Directors</TabsTrigger>
           <TabsTrigger value="awards">Awards</TabsTrigger>
           <TabsTrigger value="studios">Studios</TabsTrigger>
+          <TabsTrigger value="mods">Mods</TabsTrigger>
         </TabsList>
 
         <TabsContent value="films" className="space-y-4">
@@ -771,6 +773,10 @@ export const IndustryDatabasePanel: React.FC<IndustryDatabasePanelProps> = ({ ga
               </Tabs>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="mods" className="space-y-4">
+          <ModsPanel />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/game/ModsPanel.tsx
+++ b/src/components/game/ModsPanel.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import type { ModBundle } from '@/types/modding';
+import { normalizeModBundle } from '@/utils/modding';
+import { clearModBundle, getModBundle, saveModBundle } from '@/utils/moddingStore';
+
+export const ModsPanel: React.FC = () => {
+  const { toast } = useToast();
+
+  const [raw, setRaw] = useState('');
+  const [bundle, setBundle] = useState<ModBundle>(() => getModBundle());
+
+  useEffect(() => {
+    const b = getModBundle();
+    setBundle(b);
+    setRaw(JSON.stringify(b, null, 2));
+  }, []);
+
+  const enabledCount = useMemo(() => (bundle.mods || []).filter((m) => m.enabled).length, [bundle.mods]);
+
+  const handleReload = () => {
+    const b = getModBundle();
+    setBundle(b);
+    setRaw(JSON.stringify(b, null, 2));
+  };
+
+  const handleSave = () => {
+    try {
+      const parsed = JSON.parse(raw);
+      const normalized = normalizeModBundle(parsed);
+      saveModBundle(normalized);
+      setBundle(normalized);
+      setRaw(JSON.stringify(normalized, null, 2));
+      toast({
+        title: 'Mods saved',
+        description: 'Mod bundle saved to this browser. You may need to reload the page for all systems to pick up changes.',
+      });
+    } catch {
+      toast({
+        title: 'Invalid JSON',
+        description: 'Could not parse the mod bundle JSON.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleClear = () => {
+    clearModBundle();
+    const b = getModBundle();
+    setBundle(b);
+    setRaw(JSON.stringify(b, null, 2));
+    toast({
+      title: 'Mods cleared',
+      description: 'All mods removed from this browser. Reload to fully revert.',
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card className="card-premium">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Mod Bundle (Option A: patch overlay)</span>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline">{enabledCount}/{bundle.mods.length} enabled</Badge>
+              <Badge variant="secondary">{bundle.patches.length} patches</Badge>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Mods are applied as patches on top of the built-in data; they do not replace the default databases. Higher
+            priority mods win conflicts.
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="secondary" onClick={handleReload}>
+              Reload
+            </Button>
+            <Button size="sm" onClick={handleSave}>
+              Save
+            </Button>
+            <Button size="sm" variant="destructive" onClick={handleClear}>
+              Clear
+            </Button>
+          </div>
+
+          <Textarea
+            value={raw}
+            onChange={(e) => setRaw(e.target.value)}
+            className="font-mono text-xs min-h-[320px]"
+            spellCheck={false}
+          />
+
+          <p className="text-xs text-muted-foreground">
+            Entity types supported right now: <code>talent</code>, <code>franchise</code>, <code>publicDomainIP</code>,
+            <code>providerDeal</code>, <code>franchiseRoleSet</code>, <code>franchiseCharacterDb</code>.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/components/game/StreamingContractSystem.tsx
+++ b/src/components/game/StreamingContractSystem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -9,13 +9,14 @@ import { StreamingContract } from '@/types/streamingTypes';
 import { GameState, Project } from '@/types/game';
 import { Monitor, Tv, Award } from 'lucide-react';
 import {
-  ALL_PROVIDERS,
-  CABLE_PROVIDERS,
-  STREAMING_PROVIDERS,
+  getAllProviders,
+  getCableProviders,
+  getStreamingProviders,
   getProviderProfile,
   type DealKind,
   type ProviderDealProfile,
 } from '@/data/ProviderDealsDatabase';
+import { getModBundle } from '@/utils/moddingStore';
 import { FinancialEngine } from './FinancialEngine';
 
 interface StreamingContractSystemProps {
@@ -33,6 +34,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
 }) => {
   const { toast } = useToast();
   const [, setSelectedProject] = useState<Project | null>(null);
+  const mods = useMemo(() => getModBundle(), []);
 
   const isTVProject = (project: Project) => project.type === 'series' || project.type === 'limited-series';
   const isFilmProject = (project: Project) => project.type === 'feature' || project.type === 'documentary';
@@ -55,7 +57,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
   };
 
   const getPlatform = (dealKind: DealKind, platformId: string) => {
-    return getProviderProfile(dealKind, platformId);
+    return getProviderProfile(dealKind, platformId, mods);
   };
 
   const addWeeks = (startWeek: number, startYear: number, duration: number) => {
@@ -240,7 +242,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
 
   const signContract = (project: Project, platformId: string, dealKind: DealKind) => {
     const contract = generateContract(project, platformId, dealKind);
-    const platform = ALL_PROVIDERS.find(p => p.id === platformId);
+    const platform = getAllProviders(mods).find(p => p.id === platformId);
 
     onProjectUpdate(project.id, {
       streamingContract: contract,
@@ -277,7 +279,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
     if (!project.streamingContract) return;
 
     const contract = project.streamingContract;
-    const platform = ALL_PROVIDERS.find(p => p.id === contract.platform);
+    const platform = getAllProviders(mods).find(p => p.id === contract.platform);
 
     const totalViews = project.metrics?.streaming?.totalViews ?? project.metrics?.streamingViews ?? 0;
     if (totalViews <= 0) return;
@@ -432,7 +434,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
 
                           <TabsContent value="streaming" className="mt-4">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-96 overflow-y-auto">
-                              {STREAMING_PROVIDERS.map(provider => {
+                              {getStreamingProviders(mods).map(provider => {
                                 const issues = getDealIssues(project, provider);
                                 const contract = generateContract(project, provider.id, 'streaming');
                                 const isEpisodic = typeof contract.episodeRate === 'number';
@@ -506,7 +508,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
                           <TabsContent value="cable" className="mt-4">
                             {isTVProject(project) ? (
                               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-96 overflow-y-auto">
-                                {CABLE_PROVIDERS.map(provider => {
+                                {getCableProviders(mods).map((provider) => {
                                   const issues = getDealIssues(project, provider);
                                   const contract = generateContract(project, provider.id, 'cable');
 
@@ -600,7 +602,7 @@ export const StreamingContractSystem: React.FC<StreamingContractSystemProps> = (
             <div className="space-y-4">
               {activeContracts.map(project => {
                 const contract = project.streamingContract!;
-                const platform = ALL_PROVIDERS.find(p => p.id === contract.platform);
+                const platform = getAllProviders(mods).find(p => p.id === contract.platform);
 
                 const totalViews = project.metrics?.streaming?.totalViews ?? project.metrics?.streamingViews ?? 0;
                 const completionRate = project.metrics?.streaming?.completionRate;

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -100,6 +100,8 @@ import { MediaRelationships } from './MediaRelationships';
 import { SystemIntegration } from './SystemIntegration';
 import { saveGame } from '@/utils/saveLoad';
 import { syncAndPersistIndustryDatabase } from '@/utils/industryDatabase';
+import { applyPatchesByKey, getPatchesForEntity } from '@/utils/modding';
+import { getModBundle } from '@/utils/moddingStore';
 import { DebugControlPanel } from './DebugControlPanel';
 import { IndustryDatabasePanel } from './IndustryDatabasePanel';
 
@@ -404,8 +406,14 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
     updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 30, 'Generating talent pool...');
     
     // Initialize comprehensive talent pool
+    const mods = getModBundle();
+
     const talentGenerator = new TalentGenerator();
-    const generatedTalent = talentGenerator.generateTalentPool(300, 50);
+    const generatedTalent = applyPatchesByKey(
+      talentGenerator.generateTalentPool(300, 50),
+      getPatchesForEntity(mods, 'talent'),
+      (t) => t.id
+    );
 
     updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 60, 'Creating competitor studios...');
     
@@ -526,8 +534,16 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       })(), // Pre-generated AI releases for current and previous year
       topFilmsHistory: [],
       // Initialize Franchise & Public Domain Systems
-      franchises: FranchiseGenerator.generateInitialFranchises(30),
-      publicDomainIPs: PublicDomainGenerator.generateInitialPublicDomainIPs(50),
+      franchises: applyPatchesByKey(
+        FranchiseGenerator.generateInitialFranchises(30),
+        getPatchesForEntity(mods, 'franchise'),
+        (f) => f.id
+      ),
+      publicDomainIPs: applyPatchesByKey(
+        PublicDomainGenerator.generateInitialPublicDomainIPs(50),
+        getPatchesForEntity(mods, 'publicDomainIP'),
+        (p) => p.id
+      ),
       aiStudioProjects: [] as Project[],
     };
 

--- a/src/data/FranchiseCharacterDB.ts
+++ b/src/data/FranchiseCharacterDB.ts
@@ -1,6 +1,10 @@
 // Franchise Character Database
 // Global immutable definitions keyed by franchise ID when available, with fallback keys by parodySource/title
 
+import type { ModBundle } from '@/types/modding';
+import { applyPatchesToRecord, getPatchesForEntity } from '@/utils/modding';
+import { getModBundle } from '@/utils/moddingStore';
+
 export interface FranchiseCharacterDef {
   character_id: string;
   name: string;
@@ -28,3 +32,9 @@ export const FRANCHISE_CHARACTER_DB: Record<string, FranchiseCharacterDef[]> = {
     { character_id: 'char_director', name: 'Director', role_template_id: 'director', importance: 'crew', requiredType: 'director', is_mandatory: true },
   ],
 };
+
+export function getEffectiveFranchiseCharacterDB(mods?: ModBundle): Record<string, FranchiseCharacterDef[]> {
+  const bundle = mods ?? getModBundle();
+  const patches = getPatchesForEntity(bundle, 'franchiseCharacterDb');
+  return applyPatchesToRecord(FRANCHISE_CHARACTER_DB, patches);
+}

--- a/src/data/ProviderDealsDatabase.ts
+++ b/src/data/ProviderDealsDatabase.ts
@@ -1,4 +1,7 @@
 import type { Genre } from '@/types/game';
+import type { ModBundle } from '@/types/modding';
+import { applyPatchesByKey, getPatchesForEntity } from '@/utils/modding';
+import { getModBundle } from '@/utils/moddingStore';
 
 export type DealKind = 'streaming' | 'cable';
 
@@ -260,6 +263,24 @@ export const CABLE_PROVIDERS = PROVIDER_DEALS.filter(p => p.dealKind === 'cable'
 
 export const ALL_PROVIDERS = PROVIDER_DEALS;
 
-export function getProviderProfile(dealKind: DealKind, providerId: string) {
-  return PROVIDER_DEALS.find(p => p.dealKind === dealKind && p.id === providerId);
+export function getEffectiveProviderDeals(mods?: ModBundle): ProviderDealProfile[] {
+  const bundle = mods ?? getModBundle();
+  const patches = getPatchesForEntity(bundle, 'providerDeal');
+  return applyPatchesByKey(PROVIDER_DEALS, patches, (p) => p.id);
+}
+
+export function getAllProviders(mods?: ModBundle): ProviderDealProfile[] {
+  return getEffectiveProviderDeals(mods);
+}
+
+export function getStreamingProviders(mods?: ModBundle): ProviderDealProfile[] {
+  return getAllProviders(mods).filter((p) => p.dealKind === 'streaming');
+}
+
+export function getCableProviders(mods?: ModBundle): ProviderDealProfile[] {
+  return getAllProviders(mods).filter((p) => p.dealKind === 'cable');
+}
+
+export function getProviderProfile(dealKind: DealKind, providerId: string, mods?: ModBundle) {
+  return getAllProviders(mods).find(p => p.dealKind === dealKind && p.id === providerId);
 }

--- a/src/data/RoleDatabase.ts
+++ b/src/data/RoleDatabase.ts
@@ -1,4 +1,7 @@
 import { Franchise, GameState, Project, PublicDomainIP, ScriptCharacter } from '@/types/game';
+import type { ModBundle } from '@/types/modding';
+import { applyPatchesToRecord, getPatchesForEntity } from '@/utils/modding';
+import { getModBundle } from '@/utils/moddingStore';
 
 // Curated role sets keyed by franchise parody source (acts as stable property identity)
 const FRANCHISE_ROLE_SETS: Record<string, ScriptCharacter[]> = {
@@ -81,8 +84,15 @@ function addDefaultCameoIfMissing(roles: ScriptCharacter[]): ScriptCharacter[] {
   return roles;
 }
 
-function getRolesForFranchise(franchise: Franchise): ScriptCharacter[] {
-  const byParody = franchise.parodySource && FRANCHISE_ROLE_SETS[franchise.parodySource];
+function getEffectiveFranchiseRoleSets(mods?: ModBundle): Record<string, ScriptCharacter[]> {
+  const bundle = mods ?? getModBundle();
+  const patches = getPatchesForEntity(bundle, 'franchiseRoleSet');
+  return applyPatchesToRecord(FRANCHISE_ROLE_SETS, patches);
+}
+
+function getRolesForFranchise(franchise: Franchise, mods?: ModBundle): ScriptCharacter[] {
+  const roleSets = getEffectiveFranchiseRoleSets(mods);
+  const byParody = franchise.parodySource && roleSets[franchise.parodySource];
   if (byParody) {
     return addDefaultCameoIfMissing(ensureDirector([...byParody]));
   }
@@ -122,11 +132,11 @@ function getRolesForPublicDomain(ip: PublicDomainIP): ScriptCharacter[] {
 }
 
 export const RoleDatabase = {
-  getRolesForProject(project: Project, gameState: GameState): ScriptCharacter[] {
+  getRolesForProject(project: Project, gameState: GameState, mods?: ModBundle): ScriptCharacter[] {
     const sourceType = project.script?.sourceType;
     if (sourceType === 'franchise' && project.script.franchiseId) {
       const franchise = gameState.franchises.find(f => f.id === project.script.franchiseId);
-      return franchise ? getRolesForFranchise(franchise) : [];
+      return franchise ? getRolesForFranchise(franchise, mods) : [];
     }
     if (sourceType === 'public-domain' && project.script.publicDomainId) {
       const ip = gameState.publicDomainIPs.find(p => p.id === project.script.publicDomainId);
@@ -135,10 +145,10 @@ export const RoleDatabase = {
     return [];
   },
 
-  getRolesForSource(sourceType: 'franchise' | 'public-domain', id: string, gameState: GameState): ScriptCharacter[] {
+  getRolesForSource(sourceType: 'franchise' | 'public-domain', id: string, gameState: GameState, mods?: ModBundle): ScriptCharacter[] {
     if (sourceType === 'franchise') {
       const franchise = gameState.franchises.find(f => f.id === id);
-      return franchise ? getRolesForFranchise(franchise) : [];
+      return franchise ? getRolesForFranchise(franchise, mods) : [];
     } else {
       const ip = gameState.publicDomainIPs.find(p => p.id === id);
       return ip ? getRolesForPublicDomain(ip) : [];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,8 @@ import { LoadingProvider } from '@/contexts/LoadingContext';
 import { Suspense, lazy, useState } from 'react';
 import { loadGame, SaveGameSnapshot } from '@/utils/saveLoad';
 import { Genre } from '@/types/game';
+import { getModBundle } from '@/utils/moddingStore';
+import { applyPatchesByKey, getPatchesForEntity } from '@/utils/modding';
 
 const StudioMagnateGame = lazy(() =>
   import('@/components/game/StudioMagnateGame').then((m) => ({ default: m.StudioMagnateGame }))
@@ -41,7 +43,20 @@ const Index = () => {
       return;
     }
 
-    setLoadedSnapshot(snapshot);
+    const mods = getModBundle();
+
+    const patchedGameState = {
+      ...snapshot.gameState,
+      talent: applyPatchesByKey(snapshot.gameState.talent || [], getPatchesForEntity(mods, 'talent'), (t) => t.id),
+      franchises: applyPatchesByKey(snapshot.gameState.franchises || [], getPatchesForEntity(mods, 'franchise'), (f) => f.id),
+      publicDomainIPs: applyPatchesByKey(
+        snapshot.gameState.publicDomainIPs || [],
+        getPatchesForEntity(mods, 'publicDomainIP'),
+        (p) => p.id
+      ),
+    };
+
+    setLoadedSnapshot({ ...snapshot, gameState: patchedGameState });
     setGameConfig(null);
     setGameStarted(true);
   };

--- a/src/types/modding.ts
+++ b/src/types/modding.ts
@@ -1,0 +1,38 @@
+export type ModOp = 'insert' | 'update' | 'delete';
+
+export interface ModInfo {
+  id: string;
+  name: string;
+  version: string;
+  author?: string;
+  enabled: boolean;
+  /**
+   * Higher priority mods are applied later (they win conflicts).
+   * Defaults to 0.
+   */
+  priority?: number;
+}
+
+export interface ModPatch {
+  id: string;
+  modId: string;
+  entityType: string;
+  op: ModOp;
+  /**
+   * For update/delete, identifies the target entity (usually an id).
+   * For record-style patches, identifies the key.
+   */
+  target?: string;
+  /**
+   * For insert/update operations.
+   * - For list-style entities: typically a partial object (update) or full object (insert)
+   * - For record-style entities: typically the full value to set at `target`
+   */
+  payload?: unknown;
+}
+
+export interface ModBundle {
+  version: 1;
+  mods: ModInfo[];
+  patches: ModPatch[];
+}

--- a/src/utils/modding.ts
+++ b/src/utils/modding.ts
@@ -1,0 +1,147 @@
+import type { ModBundle, ModInfo, ModPatch } from '@/types/modding';
+
+export const MOD_BUNDLE_VERSION = 1 as const;
+
+export function createEmptyModBundle(): ModBundle {
+  return { version: MOD_BUNDLE_VERSION, mods: [], patches: [] };
+}
+
+export function normalizeModBundle(input: unknown): ModBundle {
+  const empty = createEmptyModBundle();
+  if (!input || typeof input !== 'object') return empty;
+
+  const candidate = input as Partial<ModBundle>;
+  if (candidate.version !== MOD_BUNDLE_VERSION) return empty;
+
+  const mods = Array.isArray(candidate.mods) ? (candidate.mods as ModInfo[]).filter(Boolean) : [];
+  const patches = Array.isArray(candidate.patches) ? (candidate.patches as ModPatch[]).filter(Boolean) : [];
+
+  return { version: MOD_BUNDLE_VERSION, mods, patches };
+}
+
+export function getEnabledModsSorted(bundle: ModBundle): ModInfo[] {
+  return (bundle.mods || [])
+    .filter((m) => !!m && m.enabled)
+    .slice()
+    .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0) || a.id.localeCompare(b.id));
+}
+
+export function getPatchesForEntity(bundle: ModBundle, entityType: string): ModPatch[] {
+  const enabledMods = getEnabledModsSorted(bundle);
+  const enabledIds = new Set(enabledMods.map((m) => m.id));
+  const modOrder = new Map<string, number>();
+  enabledMods.forEach((m, idx) => modOrder.set(m.id, idx));
+
+  return (bundle.patches || [])
+    .filter((p) => !!p && p.entityType === entityType && enabledIds.has(p.modId))
+    .slice()
+    .sort((a, b) => {
+      const ma = modOrder.get(a.modId) ?? 0;
+      const mb = modOrder.get(b.modId) ?? 0;
+      return ma - mb;
+    });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function deepMerge<T>(base: T, patch: unknown): T {
+  if (patch === undefined) return base;
+  if (Array.isArray(patch)) return patch as T;
+
+  if (!isPlainObject(base) || !isPlainObject(patch)) {
+    return patch as T;
+  }
+
+  const result: Record<string, unknown> = { ...(base as any) };
+  for (const [k, v] of Object.entries(patch)) {
+    const prev = (result as any)[k];
+    if (Array.isArray(v)) {
+      (result as any)[k] = v;
+    } else if (isPlainObject(v) && isPlainObject(prev)) {
+      (result as any)[k] = deepMerge(prev, v);
+    } else {
+      (result as any)[k] = v;
+    }
+  }
+
+  return result as T;
+}
+
+export function applyPatchesByKey<T>(
+  base: T[],
+  patches: ModPatch[],
+  getKey: (item: T) => string
+): T[] {
+  if (!patches.length) return base;
+
+  let next = base.slice();
+
+  for (const patch of patches) {
+    if (patch.op === 'delete') {
+      if (!patch.target) continue;
+      next = next.filter((item) => getKey(item) !== patch.target);
+      continue;
+    }
+
+    if (patch.op === 'insert') {
+      const incoming = patch.payload as T | undefined;
+      if (!incoming) continue;
+
+      const key = getKey(incoming);
+      const idx = next.findIndex((item) => getKey(item) === key);
+      if (idx === -1) {
+        next = [...next, incoming];
+      } else {
+        const merged = deepMerge(next[idx], incoming);
+        const copy = next.slice();
+        copy[idx] = merged;
+        next = copy;
+      }
+      continue;
+    }
+
+    if (patch.op === 'update') {
+      if (!patch.target) continue;
+      const idx = next.findIndex((item) => getKey(item) === patch.target);
+      if (idx === -1) continue;
+
+      const merged = deepMerge(next[idx], patch.payload);
+      const copy = next.slice();
+      copy[idx] = merged;
+      next = copy;
+      continue;
+    }
+  }
+
+  return next;
+}
+
+export function applyPatchesToRecord<T>(base: Record<string, T>, patches: ModPatch[]): Record<string, T> {
+  if (!patches.length) return base;
+
+  let next: Record<string, T> = { ...base };
+
+  for (const patch of patches) {
+    const key = patch.target;
+    if (!key) continue;
+
+    if (patch.op === 'delete') {
+      if (key in next) {
+        next = { ...next };
+        delete next[key];
+      }
+      continue;
+    }
+
+    if (patch.op === 'insert' || patch.op === 'update') {
+      const value = patch.payload as T | undefined;
+      if (value === undefined) continue;
+      next = { ...next, [key]: value };
+      continue;
+    }
+  }
+
+  return next;
+}

--- a/src/utils/moddingStore.ts
+++ b/src/utils/moddingStore.ts
@@ -1,0 +1,51 @@
+import type { ModBundle } from '@/types/modding';
+import { createEmptyModBundle, normalizeModBundle } from '@/utils/modding';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+const STORAGE_KEY = 'studio-magnate-mod-bundle-v1';
+
+let cached: ModBundle | null = null;
+
+export function invalidateModBundleCache(): void {
+  cached = null;
+}
+
+export function loadModBundle(storage?: StorageLike): ModBundle {
+  const store: StorageLike | undefined = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!store) return createEmptyModBundle();
+
+  try {
+    const raw = store.getItem(STORAGE_KEY);
+    if (!raw) return createEmptyModBundle();
+    return normalizeModBundle(JSON.parse(raw));
+  } catch {
+    return createEmptyModBundle();
+  }
+}
+
+export function getModBundle(storage?: StorageLike): ModBundle {
+  if (cached) return cached;
+  cached = loadModBundle(storage);
+  return cached;
+}
+
+export function saveModBundle(bundle: ModBundle, storage?: StorageLike): void {
+  const store: StorageLike | undefined = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!store) return;
+
+  store.setItem(STORAGE_KEY, JSON.stringify(bundle));
+  cached = bundle;
+}
+
+export function clearModBundle(storage?: StorageLike): void {
+  const store: StorageLike | undefined = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!store) return;
+
+  store.removeItem?.(STORAGE_KEY);
+  cached = createEmptyModBundle();
+}

--- a/src/utils/roleImport.ts
+++ b/src/utils/roleImport.ts
@@ -1,5 +1,5 @@
 import { GameState, Script, ScriptCharacter } from '@/types/game';
-import { FRANCHISE_CHARACTER_DB, FranchiseCharacterDef } from '@/data/FranchiseCharacterDB';
+import { FranchiseCharacterDef, getEffectiveFranchiseCharacterDB } from '@/data/FranchiseCharacterDB';
 import { RoleDatabase } from '@/data/RoleDatabase';
 import { PARODY_CHARACTER_NAME_MAP } from '@/data/ParodyCharacterNames';
 
@@ -65,10 +65,11 @@ export function importRolesForScript(script: Script, gameState: GameState): Scri
 
   if (script.sourceType === 'franchise' && script.franchiseId) {
     const franchise = gameState.franchises.find(f => f.id === script.franchiseId);
+    const characterDb = getEffectiveFranchiseCharacterDB();
     const dbKey = script.franchiseId;
-    let defs = FRANCHISE_CHARACTER_DB[dbKey];
+    let defs = characterDb[dbKey];
     if (!defs && franchise?.parodySource) {
-      defs = FRANCHISE_CHARACTER_DB[franchise.parodySource];
+      defs = characterDb[franchise.parodySource];
     }
 
     if (defs && defs.length > 0) {

--- a/tests/modding.test.ts
+++ b/tests/modding.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { ModBundle } from '@/types/modding';
+import { getProviderProfile } from '@/data/ProviderDealsDatabase';
+import { RoleDatabase } from '@/data/RoleDatabase';
+import type { Franchise, GameState } from '@/types/game';
+
+function makeEmptyMods(): ModBundle {
+  return { version: 1, mods: [], patches: [] };
+}
+
+describe('mod patch overlay (Option A)', () => {
+  it('overrides a streaming provider field without replacing the default provider list', () => {
+    const mods: ModBundle = {
+      version: 1,
+      mods: [{ id: 'm1', name: 'Provider Tweaks', version: '1.0.0', enabled: true, priority: 0 }],
+      patches: [
+        {
+          id: 'p1',
+          modId: 'm1',
+          entityType: 'providerDeal',
+          op: 'update',
+          target: 'netflix',
+          payload: { averageRate: 1234567 },
+        },
+      ],
+    };
+
+    const netflix = getProviderProfile('streaming', 'netflix', mods);
+    const amazon = getProviderProfile('streaming', 'amazon', mods);
+
+    expect(netflix?.averageRate).toBe(1234567);
+    expect(amazon?.averageRate).toBeTruthy();
+  });
+
+  it('applies higher-priority mod patches later (wins conflicts)', () => {
+    const mods: ModBundle = {
+      version: 1,
+      mods: [
+        { id: 'm1', name: 'Low', version: '1.0.0', enabled: true, priority: 0 },
+        { id: 'm2', name: 'High', version: '1.0.0', enabled: true, priority: 10 },
+      ],
+      patches: [
+        { id: 'p1', modId: 'm1', entityType: 'providerDeal', op: 'update', target: 'netflix', payload: { averageRate: 111 } },
+        { id: 'p2', modId: 'm2', entityType: 'providerDeal', op: 'update', target: 'netflix', payload: { averageRate: 222 } },
+      ],
+    };
+
+    expect(getProviderProfile('streaming', 'netflix', mods)?.averageRate).toBe(222);
+  });
+
+  it('can replace a franchise role set while still getting director + cameo defaults', () => {
+    const franchise: Franchise = {
+      id: 'f-1',
+      title: 'Space Saga',
+      originDate: '2024-01-01',
+      creatorStudioId: 'studio-1',
+      genre: ['sci-fi'],
+      tone: 'epic',
+      parodySource: 'Star Wars',
+      entries: [],
+      status: 'active',
+      franchiseTags: [],
+      culturalWeight: 50,
+      cost: 0,
+    };
+
+    const gameState: GameState = {
+      studio: {
+        id: 'studio-1',
+        name: 'Test Studio',
+        reputation: 50,
+        budget: 1,
+        founded: 2000,
+        specialties: ['drama'],
+      },
+      currentYear: 2024,
+      currentWeek: 1,
+      currentQuarter: 1,
+      projects: [],
+      talent: [],
+      scripts: [],
+      competitorStudios: [],
+      marketConditions: {
+        trendingGenres: ['drama'],
+        audiencePreferences: [],
+        economicClimate: 'stable',
+        technologicalAdvances: [],
+        regulatoryChanges: [],
+        seasonalTrends: [],
+        competitorReleases: [],
+      },
+      eventQueue: [],
+      boxOfficeHistory: [],
+      awardsCalendar: [],
+      industryTrends: [],
+      allReleases: [],
+      topFilmsHistory: [],
+      franchises: [franchise],
+      publicDomainIPs: [],
+    };
+
+    const mods: ModBundle = {
+      version: 1,
+      mods: [{ id: 'm1', name: 'Role Set Override', version: '1.0.0', enabled: true, priority: 0 }],
+      patches: [
+        {
+          id: 'p1',
+          modId: 'm1',
+          entityType: 'franchiseRoleSet',
+          op: 'update',
+          target: 'Star Wars',
+          payload: [{ id: 'lead', name: 'The Chosen One', importance: 'lead', requiredType: 'actor' }],
+        },
+      ],
+    };
+
+    const roles = RoleDatabase.getRolesForSource('franchise', franchise.id, gameState, mods);
+
+    expect(roles.some((r) => r.requiredType === 'director')).toBe(true);
+    expect(roles.some((r) => r.importance === 'minor')).toBe(true);
+  });
+
+  it('is a no-op with an empty mod bundle', () => {
+    const mods = makeEmptyMods();
+    const netflix = getProviderProfile('streaming', 'netflix', mods);
+    expect(netflix?.id).toBe('netflix');
+  });
+});


### PR DESCRIPTION
This PR introduces a patch-based modding system that overlays user-made modifications on top of the built-in game data. It enables dynamic changes to actors, directors, franchises/public domain IP, streaming/cable providers, and more, without replacing the core databases. Key features:

- ModBundle system and storage
  - New modding/types: ModBundle, ModInfo, ModPatch, ModOp, etc.
  - LocalStorage-backed ModBundle store with caching and helpers to load/save/clear patches.
  - Patches can be enabled/priority-sorted so higher-priority mods win conflicts.

- Patch application utilities
  - applyPatchesByKey and applyPatchesToRecord to apply patches to lists and records respectively.
  - normalizeModBundle to validate input, and patch retrieval helpers to collect patches per entity type.

- UI for mod management
  - New ModsPanel UI to view, edit, reload, save, and clear the mod bundle. Shows enabled mods and patch counts.
  - Patch-based edits support entity types like talent, franchise, publicDomainIP, providerDeal, franchiseRoleSet, franchiseCharacterDb, etc.

- Provider and streaming system integration
  - Provider deals now support mods via getEffectiveProviderDeals, getAllProviders, getStreamingProviders, getCableProviders, and getProviderProfile(mods).
  - StreamingContractSystem reads provider data through mods so patches can override prices/terms while preserving default provider lists.

- Data layer and game state integration
  - FranchiseCharacterDB gains getEffectiveFranchiseCharacterDB(mods) to apply patches to franchise-character mappings.
  - RoleDatabase updated to support mods when computing roles for franchises/public-domain sources.
  - StudioMagnateGame initializes talent/franchises/publicDomainIPs with patch overlays during startup.
  - Index.tsx patches the loaded game state snapshot using mod data so apps start with patched state.

- Tests
  - Added tests to validate patch overlay behavior, patch priority resolution, and no-op behavior with empty mod bundles.

What this solves
- Enables modders to customize gameplay data (actors, directors, franchises, IPs, streaming providers, etc.) without touching the core code.
- Maintains compatibility by preserving defaults and letting patches override as needed.
- Provides a simple workflow to manage, apply, and persist mods across sessions.

Files touched/added (high level)
- New: src/types/modding.ts, src/utils/modding.ts, src/utils/moddingStore.ts
- New UI: src/components/game/ModsPanel.tsx
- UI and data wiring: Enhanced IndustryDatabasePanel.tsx, StreamingContractSystem.tsx, FranchiseCharacterDB.ts, ProviderDealsDatabase.ts, RoleDatabase.ts, StudioMagnateGame.tsx, pages/Index.tsx
- Data integration: FranchiseCharacterDB getEffectiveFranchiseCharacterDB, RoleDatabase changes, ProviderDealsDatabase additional helpers
- Tests: tests/modding.test.ts

Notes
- The system is designed to be backward-compatible: if no mods are present, behavior remains identical to the original data.
- Higher-priority mods win conflicts when patching provider data and other entities.
- Mod Overlays are applied in-browser; a page reload may be required for some systems to fully pick up changes.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/coxv2omblmca
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/27
Author: Evan Lewis