### PR TITLE
Enable long-term execution mode with runLongTermSimulation and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "test": "npx vitest run",
     "test:watch": "npx vitest",
+    "test:sim": "npx vitest run tests/longTermSimulation.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/src/simulation/longTermRunner.ts
+++ b/src/simulation/longTermRunner.ts
@@ -1,0 +1,106 @@
+import { GameState, Project } from '@/types/game';
+import { TimeSystem } from '@/components/game/TimeSystem';
+import { BoxOfficeSystem } from '@/components/game/BoxOfficeSystem';
+import { FinancialEngine } from '@/components/game/FinancialEngine';
+
+export type LongTermSimulationResult = {
+  finalState: GameState;
+  weeksSimulated: number;
+  totalStudioRevenueShare: number;
+  totalBoxOfficeGross: number;
+};
+
+const getAbsWeek = (year: number, week: number) => (year * 52) + week;
+
+export const runLongTermSimulation = (
+  initialState: GameState,
+  weeksToSimulate: number
+): LongTermSimulationResult => {
+  // Avoid mutating the caller's object graph (projects carry nested fields)
+  const clone: <T>(value: T) => T =
+    typeof structuredClone === 'function'
+      ? structuredClone
+      : (value) => JSON.parse(JSON.stringify(value));
+
+  let state: GameState = clone(initialState);
+
+  let totalStudioRevenueShare = 0;
+  let totalBoxOfficeGross = 0;
+
+  const applyStudioShare = (projectBefore: Project, projectAfter: Project) => {
+    const before = projectBefore.metrics?.boxOfficeTotal || 0;
+    const after = projectAfter.metrics?.boxOfficeTotal || 0;
+    const delta = after - before;
+    if (delta <= 0) return;
+
+    totalBoxOfficeGross += delta;
+    const studioShare = delta * 0.55;
+    totalStudioRevenueShare += studioShare;
+
+    state = {
+      ...state,
+      studio: {
+        ...state.studio,
+        budget: (state.studio.budget || 0) + studioShare,
+      },
+    };
+  };
+
+  for (let i = 0; i < weeksToSimulate; i += 1) {
+    const currentAbs = getAbsWeek(state.currentYear, state.currentWeek);
+
+    const updatedProjects: Project[] = state.projects.map((project) => {
+      let updated = project;
+
+      // Scheduled releases become released at their target week
+      const scheduledWeek = project.scheduledReleaseWeek || project.releaseWeek;
+      const scheduledYear = project.scheduledReleaseYear || project.releaseYear;
+
+      if (project.status === 'scheduled-for-release' && scheduledWeek && scheduledYear) {
+        const scheduledAbs = getAbsWeek(scheduledYear, scheduledWeek);
+        if (scheduledAbs === currentAbs) {
+          // BoxOfficeSystem will set released metrics including opening revenue (Week 0)
+          updated = BoxOfficeSystem.initializeRelease({ ...project }, scheduledWeek, scheduledYear);
+          applyStudioShare(project, updated);
+          return updated;
+        }
+      }
+
+      if (project.status === 'released' && project.type !== 'series' && project.type !== 'limited-series') {
+        const before = project;
+        updated = BoxOfficeSystem.processWeeklyRevenue({ ...project }, state.currentWeek, state.currentYear);
+        applyStudioShare(before, updated);
+        return updated;
+      }
+
+      return updated;
+    });
+
+    state = {
+      ...state,
+      projects: updatedProjects,
+    };
+
+    FinancialEngine.performMemoryCleanup(state.currentWeek, state.currentYear);
+
+    const nextTime = TimeSystem.advanceWeek({
+      currentWeek: state.currentWeek,
+      currentYear: state.currentYear,
+      currentQuarter: state.currentQuarter,
+    });
+
+    state = {
+      ...state,
+      currentWeek: nextTime.currentWeek,
+      currentYear: nextTime.currentYear,
+      currentQuarter: nextTime.currentQuarter,
+    };
+  }
+
+  return {
+    finalState: state,
+    weeksSimulated: weeksToSimulate,
+    totalStudioRevenueShare,
+    totalBoxOfficeGross,
+  };
+};

--- a/tests/longTermSimulation.test.ts
+++ b/tests/longTermSimulation.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState, Project, Script } from '@/types/game';
+import { runLongTermSimulation } from '@/simulation/longTermRunner';
+
+const makeBudget = (total: number) => ({
+  total,
+  allocated: { aboveTheLine: 0, belowTheLine: 0, postProduction: 0, marketing: 0, distribution: 0, contingency: 0 },
+  spent: { aboveTheLine: 0, belowTheLine: 0, postProduction: 0, marketing: 0, distribution: 0, contingency: 0 },
+  overages: { aboveTheLine: 0, belowTheLine: 0, postProduction: 0, marketing: 0, distribution: 0, contingency: 0 },
+});
+
+const makeScript = (id: string, title: string, genre: any, budget: number): Script => ({
+  id,
+  title,
+  genre,
+  logline: 'Test logline',
+  writer: 'Test Writer',
+  pages: 100,
+  quality: 75,
+  budget,
+  developmentStage: 'final',
+  themes: [],
+  targetAudience: 'general',
+  estimatedRuntime: 110,
+  characteristics: {
+    tone: 'balanced',
+    pacing: 'steady',
+    dialogue: 'naturalistic',
+    visualStyle: 'realistic',
+    commercialAppeal: 7,
+    criticalPotential: 7,
+    cgiIntensity: 'minimal',
+  },
+});
+
+const makeReleasedFilm = (overrides: Partial<Project> = {}): Project => {
+  const budget = overrides.budget?.total ?? 40_000_000;
+
+  return {
+    id: overrides.id ?? 'p1',
+    title: overrides.title ?? 'Test Film',
+    script: overrides.script ?? makeScript('s1', 'Test Film', 'action', budget),
+    type: 'feature',
+    currentPhase: 'release',
+    budget: overrides.budget ?? makeBudget(budget),
+    cast: [],
+    crew: [],
+    timeline: {
+      preProduction: { start: new Date(), end: new Date() },
+      principalPhotography: { start: new Date(), end: new Date() },
+      postProduction: { start: new Date(), end: new Date() },
+      release: new Date(),
+      milestones: [],
+    },
+    locations: [],
+    distributionStrategy: {
+      primary: { platform: 'Theatrical', type: 'theatrical', revenue: { type: 'box-office', studioShare: 55 } },
+      international: [],
+      windows: [],
+      marketingBudget: 10_000_000,
+    },
+    status: 'released',
+    postTheatricalEligible: false,
+    metrics: {
+      inTheaters: true,
+      boxOfficeTotal: 25_000_000,
+      theaterCount: 3200,
+      weeksSinceRelease: 0,
+      criticsScore: 70,
+      audienceScore: 75,
+      boxOfficeStatus: 'Opening',
+      theatricalRunLocked: false,
+      lastWeeklyRevenue: 25_000_000,
+    },
+    phaseDuration: 0,
+    contractedTalent: [],
+    developmentProgress: {
+      scriptCompletion: 100,
+      budgetApproval: 100,
+      talentAttached: 100,
+      locationSecured: 100,
+      completionThreshold: 100,
+      issues: [],
+    },
+    ...overrides,
+  };
+};
+
+describe('long-term simulation runner', () => {
+  it('can advance years without producing NaNs or negative totals', () => {
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = () => {};
+
+    try {
+      const startYear = 2025;
+
+      const initial: GameState = {
+        studio: {
+        id: 'player-studio',
+        name: 'Test Studio',
+        reputation: 50,
+        budget: 10_000_000,
+        founded: startYear,
+        specialties: ['drama'],
+        debt: 0,
+        lastProjectWeek: 0,
+        weeksSinceLastProject: 0,
+      },
+      currentYear: startYear,
+      currentWeek: 1,
+      currentQuarter: 1,
+      projects: [
+        makeReleasedFilm({
+          id: 'released-1',
+          releaseWeek: 1,
+          releaseYear: startYear,
+        }),
+        makeReleasedFilm({
+          id: 'scheduled-1',
+          title: 'Scheduled Film',
+          status: 'scheduled-for-release',
+          metrics: {
+            inTheaters: false,
+            boxOfficeTotal: 0,
+            theaterCount: 0,
+            weeksSinceRelease: 0,
+            criticsScore: 72,
+            audienceScore: 74,
+            boxOfficeStatus: 'Scheduled',
+            theatricalRunLocked: false,
+          },
+          scheduledReleaseWeek: 10,
+          scheduledReleaseYear: startYear,
+          releaseWeek: 10,
+          releaseYear: startYear,
+        }),
+      ],
+      talent: [],
+      scripts: [],
+      competitorStudios: [],
+      marketConditions: {
+        trendingGenres: ['action', 'drama', 'comedy'],
+        audiencePreferences: [],
+        economicClimate: 'stable',
+        technologicalAdvances: [],
+        regulatoryChanges: [],
+        seasonalTrends: [],
+        competitorReleases: [],
+        awardsSeasonActive: false,
+      },
+      eventQueue: [],
+      boxOfficeHistory: [],
+      awardsCalendar: [],
+      industryTrends: [],
+      allReleases: [],
+      topFilmsHistory: [],
+      franchises: [],
+      publicDomainIPs: [],
+      aiStudioProjects: [],
+    };
+
+    const { finalState, totalBoxOfficeGross, totalStudioRevenueShare } = runLongTermSimulation(initial, 52 * 10);
+
+    expect(Number.isFinite(totalBoxOfficeGross)).toBe(true);
+    expect(Number.isFinite(totalStudioRevenueShare)).toBe(true);
+    expect(totalBoxOfficeGross).toBeGreaterThan(0);
+    expect(totalStudioRevenueShare).toBeGreaterThan(0);
+
+    const boxOfficeTotals = finalState.projects.map(p => p.metrics?.boxOfficeTotal ?? 0);
+    for (const total of boxOfficeTotals) {
+      expect(Number.isFinite(total)).toBe(true);
+      expect(total).toBeGreaterThanOrEqual(0);
+    }
+
+    expect(finalState.studio.budget).toBeGreaterThan(0);
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+  });
+});


### PR DESCRIPTION
Adds an execution-mode long-term simulation runner and tests to debug and tweak extended simulations.

What changed:
- Added src/simulation/longTermRunner.ts with runLongTermSimulation
  - Clones initial state to avoid mutating input graphs
  - Steps through weeks, handles scheduled releases, and processes weekly box-office revenue
  - Aggregates total studio revenue share and box-office gross
  - Integrates with existing systems (TimeSystem, BoxOfficeSystem, FinancialEngine) and advances time each week
  - Returns final state, weeks simulated, totalStudioRevenueShare, totalBoxOfficeGross
- Added tests/longTermSimulation.test.ts
  - Provides a test harness to simulate 10 years and ensure stability (no NaNs, no negative totals)
  - Verifies finiteness of totals and positive studio budget growth
  - Uses helper creators to build initial studio/state and released/scheduled film projects
- Updated package.json to expose a test:sim script for quick execution of the long-term simulation tests

How this helps:
- Enables an execution-mode workflow to observe long-term simulation behavior and identify tweaks needed for stable gameplay economics
- Provides automated checks that long-running simulations stay finite and sensible, preventing regressions
- Quick feedback loop via npm run test:sim to run focused long-term tests without running the full suite


https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/le7h92hcqicr
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/34
Author: Evan Lewis