### PR TITLE
Revamp LoreHub: TEW-style two-pane encyclopedia with clickable Talent Profiles and UI-driven TalentProfileDialog

### DIFF
--- a/src/components/game/CastingBoard.tsx
+++ b/src/components/game/CastingBoard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Project, TalentPerson, ProductionRole, ScriptCharacter } from '@/types/game';
 import { useGameStore } from '@/game/store';
+import { useUiStore } from '@/game/uiStore';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -26,6 +27,7 @@ export const CastingBoard: React.FC<CastingBoardProps> = ({
   const gameState = useGameStore((s) => s.game);
   const replaceProject = useGameStore((s) => s.replaceProject);
   const updateTalent = useGameStore((s) => s.updateTalent);
+  const openTalentProfile = useUiStore((s) => s.openTalentProfile);
   const { toast } = useToast();
   const [filters, setFilters] = useState<CastingFilters>({
     talentType: 'all',
@@ -259,7 +261,13 @@ export const CastingBoard: React.FC<CastingBoardProps> = ({
                             <AvatarFallback>{talent.name.split(' ').map(n => n[0]).join('')}</AvatarFallback>
                           </Avatar>
                           <div className="flex-1">
-                            <p className="font-medium">{talent.name}</p>
+                            <button
+                              type="button"
+                              className="text-left font-medium hover:underline"
+                              onClick={() => openTalentProfile(talent.id)}
+                            >
+                              {talent.name}
+                            </button>
                             <p className="text-sm text-muted-foreground">{role.role}</p>
                           </div>
                           <div className="text-right">
@@ -289,12 +297,28 @@ export const CastingBoard: React.FC<CastingBoardProps> = ({
                     </AvatarFallback>
                   </Avatar>
                   <div>
-                    <h3 className="font-bold text-lg">{talent.name}</h3>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="font-bold text-lg hover:underline"
+                        onClick={() => openTalentProfile(talent.id)}
+                      >
+                        {talent.name}
+                      </button>
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0"
+                        onClick={() => openTalentProfile(talent.id)}
+                      >
+                        Profile
+                      </Button>
+                    </div>
                     <Badge variant="outline" className="capitalize">
                       {talent.type}
                     </Badge>
                   </div>
-                </div>
                 <div className="text-right">
                   <div className="flex items-center space-x-1 text-sm text-muted-foreground">
                     <ReputationIcon size={14} />

--- a/src/components/game/CastingRoleManager.tsx
+++ b/src/components/game/CastingRoleManager.tsx
@@ -1,6 +1,7 @@
 // Role-Based Casting System - Assign specific actors to specific roles
 import React, { useState } from 'react';
 import { Project, TalentPerson, ScriptCharacter } from '@/types/game';
+import { useUiStore } from '@/game/uiStore';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -37,6 +38,7 @@ export const CastingRoleManager: React.FC<CastingRoleManagerProps> = ({
   studioBudget
 }) => {
   const { toast } = useToast();
+  const openTalentProfile = useUiStore((s) => s.openTalentProfile);
   const [castingDialogOpen, setCastingDialogOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<RoleCast | null>(null);
   const [talentFilter, setTalentFilter] = useState('');
@@ -405,13 +407,26 @@ export const CastingRoleManager: React.FC<CastingRoleManagerProps> = ({
                         </div>
                       </div>
                     </div>
-                    <Button
-                      onClick={() => handleCastTalent(talent)}
-                      disabled={!canAfford}
-                      variant={canAfford ? "default" : "outline"}
-                    >
-                      {canAfford ? "Cast" : "Can't Afford"}
-                    </Button>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="h-auto p-0"
+                        onClick={() => {
+                          setCastingDialogOpen(false);
+                          openTalentProfile(talent.id);
+                        }}
+                      >
+                        Profile
+                      </Button>
+                      <Button
+                        onClick={() => handleCastTalent(talent)}
+                        disabled={!canAfford}
+                        variant={canAfford ? "default" : "outline"}
+                      >
+                        {canAfford ? "Cast" : "Can't Afford"}
+                      </Button>
+                    </div>
                   </div>
                 );
               })

--- a/src/components/game/LoreHub.tsx
+++ b/src/components/game/LoreHub.tsx
@@ -1,185 +1,453 @@
-import React, { Suspense } from 'react';
+import React, { useMemo, useState } from 'react';
+import type { Franchise, PublicDomainIP, Studio } from '@/types/game';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
 import { useGameStore } from '@/game/store';
-import { Book, Building, Users, Film } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Book, Building, Film, Search } from 'lucide-react';
 
-const TalentBiographySystem = React.lazy(() =>
-  import('./TalentBiographySystem').then(m => ({ default: m.TalentBiographySystem }))
-);
+const formatMoney = (amount: number) => "$" + (amount / 1_000_000).toFixed(0) + "M";
 
-/** Competitor studio lore cards using StudioGenerator profiles */
-const CompetitorStudioLore: React.FC = () => {
-  const gameState = useGameStore((s) => s.game);
-  if (!gameState) return null;
-
-  const studios = gameState.competitorStudios || [];
-
+const TwoPaneLayout: React.FC<{
+  title: React.ReactNode;
+  search: string;
+  setSearch: (v: string) => void;
+  list: React.ReactNode;
+  detail: React.ReactNode;
+}> = ({ title, search, setSearch, list, detail }) => {
   return (
-    <div className="space-y-4">
-      {studios.length === 0 && (
-        <p className="text-muted-foreground text-sm">No competitor studios in the world yet.</p>
-      )}
-      {studios.map((studio) => (
-        <Card key={studio.id}>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Building className="h-5 w-5 text-primary" />
-              {studio.name}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {studio.personality && (
-              <div>
-                <h4 className="text-sm font-semibold mb-1">Personality</h4>
-                <p className="text-sm text-muted-foreground">{studio.personality}</p>
-              </div>
-            )}
-            {studio.brandIdentity && (
-              <div>
-                <h4 className="text-sm font-semibold mb-1">Brand Identity</h4>
-                <p className="text-sm text-muted-foreground">{studio.brandIdentity}</p>
-              </div>
-            )}
-            {studio.businessTendency && (
-              <div>
-                <h4 className="text-sm font-semibold mb-1">Business Approach</h4>
-                <p className="text-sm text-muted-foreground">{studio.businessTendency}</p>
-              </div>
-            )}
-            <div className="flex flex-wrap gap-2">
-              {(studio.specialties || []).map((g) => (
-                <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
-              ))}
-              {studio.riskTolerance && (
-                <Badge variant="secondary" className="capitalize">{studio.riskTolerance} risk</Badge>
-              )}
-            </div>
-            <div className="flex gap-4 text-xs text-muted-foreground">
-              <span>Reputation: {Math.round(studio.reputation)}/100</span>
-              <span>Budget: ${(studio.budget / 1_000_000).toFixed(0)}M</span>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
+    <div className="grid grid-cols-1 lg:grid-cols-[340px_1fr] gap-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search..."
+              className="pl-9"
+            />
+          </div>
+          {list}
+        </CardContent>
+      </Card>
+
+      {detail}
     </div>
   );
 };
 
-/** Franchise / IP lore cards */
-const FranchiseLore: React.FC = () => {
-  const gameState = useGameStore((s) => s.game);
-  if (!gameState) return null;
+const StudioEncyclopedia: React.FC<{ studios: Studio[] }> = ({ studios }) => {
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(studios[0]?.id ?? null);
 
-  const franchises = gameState.franchises || [];
-  const publicDomain = gameState.publicDomainIPs || [];
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return studios;
+    return studios.filter(s => s.name.toLowerCase().includes(q));
+  }, [studios, search]);
+
+  const selected = useMemo(() => {
+    return (
+      studios.find(s => s.id === selectedId) ||
+      filtered[0] ||
+      studios[0] ||
+      null
+    );
+  }, [filtered, selectedId, studios]);
 
   return (
-    <div className="space-y-6">
-      {franchises.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold flex items-center gap-2">
-            <Film className="h-5 w-5 text-primary" />
-            Franchises ({franchises.length})
-          </h3>
-          {franchises.map((f) => (
-            <Card key={f.id}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{f.title}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {f.description && <p className="text-sm text-muted-foreground">{f.description}</p>}
-                <div className="flex flex-wrap gap-2">
-                  {f.genre && f.genre.map((g) => (
-                    <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
-                  ))}
-                  {f.culturalWeight != null && <Badge variant="secondary">Cultural Weight: {Math.round(f.culturalWeight)}</Badge>}
-                  {f.status && <Badge variant="outline" className="capitalize">{f.status}</Badge>}
+    <TwoPaneLayout
+      title={
+        <span className="flex items-center gap-2">
+          <Building className="h-4 w-4 text-primary" />
+          Studios
+        </span>
+      }
+      search={search}
+      setSearch={setSearch}
+      list={
+        <ScrollArea className="h-[60vh] pr-3">
+          <div className="space-y-2">
+            {filtered.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                className={cn(
+                  'w-full rounded-md border p-3 text-left transition-colors hover:bg-accent',
+                  selected?.id === s.id && 'border-primary bg-primary/5'
+                )}
+                onClick={() => setSelectedId(s.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">{s.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      Rep: {Math.round(s.reputation || 0)}/100 • Budget: {formatMoney(s.budget || 0)}
+                    </div>
+                  </div>
+                  {s.riskTolerance && (
+                    <Badge variant="secondary" className="capitalize">{s.riskTolerance}</Badge>
+                  )}
                 </div>
-                {f.franchiseTags && f.franchiseTags.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
-                    {f.franchiseTags.slice(0, 8).map((tag) => (
-                      <Badge key={tag} variant="outline" className="text-xs">{tag}</Badge>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {(s.specialties || []).slice(0, 6).map((g) => (
+                    <Badge key={g} variant="outline" className="capitalize text-xs">{g}</Badge>
+                  ))}
+                </div>
+              </button>
+            ))}
+
+            {filtered.length === 0 && (
+              <div className="text-sm text-muted-foreground">No studios match your search.</div>
+            )}
+          </div>
+        </ScrollArea>
+      }
+      detail={
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">{selected?.name ?? 'Studio'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!selected ? (
+              <div className="text-sm text-muted-foreground">No studio selected.</div>
+            ) : (
+              <>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary">Rep: {Math.round(selected.reputation || 0)}/100</Badge>
+                  <Badge variant="outline">Founded: {selected.founded || '—'}</Badge>
+                  <Badge variant="outline">Budget: {formatMoney(selected.budget || 0)}</Badge>
+                  {selected.riskTolerance && (
+                    <Badge variant="secondary" className="capitalize">{selected.riskTolerance} risk</Badge>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Specialties</div>
+                  <div className="flex flex-wrap gap-2">
+                    {(selected.specialties || []).map((g) => (
+                      <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
                     ))}
                   </div>
-                )}
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
-
-      {publicDomain.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-lg font-semibold flex items-center gap-2">
-            <Book className="h-5 w-5 text-primary" />
-            Public Domain IPs ({publicDomain.length})
-          </h3>
-          {publicDomain.map((ip) => (
-            <Card key={ip.id}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{ip.name}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {ip.description && (
-                  <p className="text-sm text-muted-foreground">{ip.description}</p>
-                )}
-                <div className="flex flex-wrap gap-2">
-                  {ip.genreFlexibility && ip.genreFlexibility.map((g) => (
-                    <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
-                  ))}
-                  <Badge variant="secondary" className="capitalize">{ip.domainType}</Badge>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
 
-      {franchises.length === 0 && publicDomain.length === 0 && (
-        <p className="text-muted-foreground text-sm">No franchises or public domain IPs discovered yet.</p>
-      )}
-    </div>
+                <Separator />
+
+                <div className="space-y-3">
+                  {selected.brandIdentity && (
+                    <div>
+                      <div className="text-sm font-medium">Brand</div>
+                      <div className="text-sm text-muted-foreground">{selected.brandIdentity}</div>
+                    </div>
+                  )}
+
+                  {selected.personality && (
+                    <div>
+                      <div className="text-sm font-medium">Personality</div>
+                      <div className="text-sm text-muted-foreground">{selected.personality}</div>
+                    </div>
+                  )}
+
+                  {selected.businessTendency && (
+                    <div>
+                      <div className="text-sm font-medium">Business Approach</div>
+                      <div className="text-sm text-muted-foreground">{selected.businessTendency}</div>
+                    </div>
+                  )}
+
+                  {!selected.brandIdentity && !selected.personality && !selected.businessTendency && (
+                    <div className="text-sm text-muted-foreground">
+                      This studio doesn't have any additional lore fields yet.
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      }
+    />
+  );
+};
+
+const FranchiseEncyclopedia: React.FC<{ franchises: Franchise[] }> = ({ franchises }) => {
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(franchises[0]?.id ?? null);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return franchises;
+    return franchises.filter(f => f.title.toLowerCase().includes(q));
+  }, [franchises, search]);
+
+  const selected = useMemo(() => {
+    return franchises.find(f => f.id === selectedId) || filtered[0] || franchises[0] || null;
+  }, [filtered, franchises, selectedId]);
+
+  return (
+    <TwoPaneLayout
+      title={
+        <span className="flex items-center gap-2">
+          <Film className="h-4 w-4 text-primary" />
+          Franchises
+        </span>
+      }
+      search={search}
+      setSearch={setSearch}
+      list={
+        <ScrollArea className="h-[60vh] pr-3">
+          <div className="space-y-2">
+            {filtered.map((f) => (
+              <button
+                key={f.id}
+                type="button"
+                className={cn(
+                  'w-full rounded-md border p-3 text-left transition-colors hover:bg-accent',
+                  selected?.id === f.id && 'border-primary bg-primary/5'
+                )}
+                onClick={() => setSelectedId(f.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">{f.title}</div>
+                    <div className="text-xs text-muted-foreground">Status: {f.status} • Tone: {f.tone}</div>
+                  </div>
+                  <Badge variant="secondary">{Math.round(f.culturalWeight)}</Badge>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {(f.genre || []).slice(0, 6).map((g) => (
+                    <Badge key={g} variant="outline" className="capitalize text-xs">{g}</Badge>
+                  ))}
+                </div>
+              </button>
+            ))}
+
+            {filtered.length === 0 && (
+              <div className="text-sm text-muted-foreground">No franchises match your search.</div>
+            )}
+          </div>
+        </ScrollArea>
+      }
+      detail={
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">{selected?.title ?? 'Franchise'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!selected ? (
+              <div className="text-sm text-muted-foreground">No franchise selected.</div>
+            ) : (
+              <>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="outline" className="capitalize">{selected.status}</Badge>
+                  <Badge variant="secondary" className="capitalize">{selected.tone}</Badge>
+                  <Badge variant="outline">Cultural Weight: {Math.round(selected.culturalWeight)}</Badge>
+                  <Badge variant="outline">License: {formatMoney(selected.cost || 0)}</Badge>
+                </div>
+
+                {selected.description && (
+                  <div className="text-sm text-muted-foreground">{selected.description}</div>
+                )}
+
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Genres</div>
+                  <div className="flex flex-wrap gap-2">
+                    {(selected.genre || []).map((g) => (
+                      <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
+                    ))}
+                  </div>
+                </div>
+
+                {(selected.franchiseTags || []).length > 0 && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <div className="text-sm font-medium">Tags</div>
+                      <div className="flex flex-wrap gap-2">
+                        {(selected.franchiseTags || []).slice(0, 16).map((t) => (
+                          <Badge key={t} variant="secondary">{t}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      }
+    />
+  );
+};
+
+const PublicDomainEncyclopedia: React.FC<{ ips: PublicDomainIP[] }> = ({ ips }) => {
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(ips[0]?.id ?? null);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return ips;
+    return ips.filter(ip => ip.name.toLowerCase().includes(q));
+  }, [ips, search]);
+
+  const selected = useMemo(() => {
+    return ips.find(ip => ip.id === selectedId) || filtered[0] || ips[0] || null;
+  }, [filtered, ips, selectedId]);
+
+  return (
+    <TwoPaneLayout
+      title={
+        <span className="flex items-center gap-2">
+          <Book className="h-4 w-4 text-primary" />
+          Public Domain
+        </span>
+      }
+      search={search}
+      setSearch={setSearch}
+      list={
+        <ScrollArea className="h-[60vh] pr-3">
+          <div className="space-y-2">
+            {filtered.map((ip) => (
+              <button
+                key={ip.id}
+                type="button"
+                className={cn(
+                  'w-full rounded-md border p-3 text-left transition-colors hover:bg-accent',
+                  selected?.id === ip.id && 'border-primary bg-primary/5'
+                )}
+                onClick={() => setSelectedId(ip.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">{ip.name}</div>
+                    <div className="text-xs text-muted-foreground capitalize">{ip.domainType}</div>
+                  </div>
+                  <Badge variant="secondary">{Math.round(ip.reputationScore || 0)}</Badge>
+                </div>
+              </button>
+            ))}
+
+            {filtered.length === 0 && (
+              <div className="text-sm text-muted-foreground">No public domain IPs match your search.</div>
+            )}
+          </div>
+        </ScrollArea>
+      }
+      detail={
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">{selected?.name ?? 'Public Domain IP'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!selected ? (
+              <div className="text-sm text-muted-foreground">No IP selected.</div>
+            ) : (
+              <>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary" className="capitalize">{selected.domainType}</Badge>
+                  <Badge variant="outline">Iconic: {Math.round(selected.reputationScore || 0)}/100</Badge>
+                  <Badge variant="outline">Cost: {formatMoney(selected.cost || 0)}</Badge>
+                </div>
+
+                {selected.description && (
+                  <div className="text-sm text-muted-foreground">{selected.description}</div>
+                )}
+
+                {(selected.genreFlexibility || []).length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Genre Flexibility</div>
+                    <div className="flex flex-wrap gap-2">
+                      {(selected.genreFlexibility || []).slice(0, 10).map((g) => (
+                        <Badge key={g} variant="outline" className="capitalize">{g}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {(selected.coreElements || []).length > 0 && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      <div className="text-sm font-medium">Core Elements</div>
+                      <div className="flex flex-wrap gap-2">
+                        {(selected.coreElements || []).slice(0, 16).map((e, i) => (
+                          <Badge key={i} variant="secondary">{e}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {(selected.requiredElements || []).length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Required Elements</div>
+                    <div className="flex flex-wrap gap-2">
+                      {(selected.requiredElements || []).slice(0, 16).map((e, i) => (
+                        <Badge key={i} variant="outline">{e}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      }
+    />
   );
 };
 
 export const LoreHub: React.FC = () => {
   const gameState = useGameStore((s) => s.game);
 
+  const studios = useMemo(() => {
+    if (!gameState) return [] as Studio[];
+    const all = [gameState.studio, ...(gameState.competitorStudios || [])].filter(Boolean);
+    return all.sort((a, b) => (b.reputation || 0) - (a.reputation || 0));
+  }, [gameState]);
+
   if (!gameState) {
-    return <div className="p-6 text-sm text-muted-foreground">Loading lore...</div>;
+    return <div className="p-6 text-sm text-muted-foreground">Loading encyclopedia...</div>;
   }
 
+  const franchises = gameState.franchises || [];
+  const publicDomain = gameState.publicDomainIPs || [];
+
   return (
-    <Tabs defaultValue="talent" className="space-y-4">
+    <Tabs defaultValue="studios" className="space-y-4">
       <TabsList>
-        <TabsTrigger value="talent">
-          <Users className="mr-1.5 h-4 w-4" />
-          Talent & Bios
-        </TabsTrigger>
         <TabsTrigger value="studios">
           <Building className="mr-1.5 h-4 w-4" />
-          Competitor Studios
+          Studios
         </TabsTrigger>
         <TabsTrigger value="franchises">
           <Film className="mr-1.5 h-4 w-4" />
-          Franchises & IPs
+          Franchises
+        </TabsTrigger>
+        <TabsTrigger value="public-domain">
+          <Book className="mr-1.5 h-4 w-4" />
+          Public Domain
         </TabsTrigger>
       </TabsList>
 
-      <TabsContent value="talent">
-        <Suspense fallback={<div className="p-4 text-sm text-muted-foreground">Loading talent biographies...</div>}>
-          <TalentBiographySystem gameState={gameState} />
-        </Suspense>
-      </TabsContent>
-
       <TabsContent value="studios">
-        <CompetitorStudioLore />
+        <StudioEncyclopedia studios={studios} />
       </TabsContent>
 
       <TabsContent value="franchises">
-        <FranchiseLore />
+        <FranchiseEncyclopedia franchises={franchises} />
+      </TabsContent>
+
+      <TabsContent value="public-domain">
+        <PublicDomainEncyclopedia ips={publicDomain} />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -104,6 +104,7 @@ import { getModBundle } from '@/utils/moddingStore';
 import { DebugControlPanel } from './DebugControlPanel';
 import { IndustryDatabasePanel } from './IndustryDatabasePanel';
 import { LoreHub } from './LoreHub';
+import { TalentProfileDialog } from './TalentProfileDialog';
 import { StudioIconRenderer as StudioIconRendererLazy } from './StudioIconCustomizer';
 
 // Ensure AI films have credited talent so awards/filmographies have real people to reference
@@ -2616,7 +2617,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
                  </DropdownMenuItem>
                  <DropdownMenuItem onClick={() => handlePhaseChange('lore')}>
                    <ClapperboardIcon className="mr-2" size={16} />
-                   Lore & Encyclopedia
+                   Encyclopedia
                  </DropdownMenuItem>
                </DropdownMenuContent>
              </DropdownMenu>
@@ -3185,6 +3186,8 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
           ceremony={currentAwardShow}
         />
       )}
+
+      <TalentProfileDialog />
     </div>
     </>
   );

--- a/src/components/game/TalentAgencySystem.tsx
+++ b/src/components/game/TalentAgencySystem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useUiStore } from '@/game/uiStore';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -24,6 +25,7 @@ export const TalentAgencySystem: React.FC<TalentAgencySystemProps> = ({
   onNegotiateDeal,
   onCreateHold
 }) => {
+  const openTalentProfile = useUiStore((s) => s.openTalentProfile);
   const [selectedAgent, setSelectedAgent] = useState<TalentAgent | null>(null);
   const [selectedTalent, setSelectedTalent] = useState<TalentPerson | null>(null);
   const [dealType, setDealType] = useState<'standard' | 'priority' | 'exclusive'>('standard');
@@ -150,11 +152,25 @@ export const TalentAgencySystem: React.FC<TalentAgencySystemProps> = ({
                     <CardContent className="p-3">
                       <div className="flex justify-between items-start">
                         <div>
-                          <h4 className="font-medium">{person.name}</h4>
+                          <div className="flex items-center gap-2">
+                            <h4 className="font-medium">{person.name}</h4>
+                            <Button
+                              type="button"
+                              variant="link"
+                              size="sm"
+                              className="h-auto p-0"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                openTalentProfile(person.id);
+                              }}
+                            >
+                              Profile
+                            </Button>
+                          </div>
                           <p className="text-sm text-muted-foreground capitalize">{person.type}</p>
-                            <Badge variant="outline" className="text-xs mt-1">
-                              Rep: {Math.round(person.reputation)}/100
-                            </Badge>
+                          <Badge variant="outline" className="text-xs mt-1">
+                            Rep: {Math.round(person.reputation)}/100
+                          </Badge>
                         </div>
                         <div className="text-right text-sm">
                           <p className="font-medium">
@@ -174,7 +190,7 @@ export const TalentAgencySystem: React.FC<TalentAgencySystemProps> = ({
           {selectedAgent && selectedTalent && (
             <div className="mt-6 p-4 border rounded-lg bg-muted/50">
               <h3 className="text-lg font-semibold mb-3">Negotiate Deal</h3>
-              <div className="flex gap-4 mb-4">
+              <div className="flex flex-wrap gap-4 mb-4">
                 <Button
                   variant={dealType === 'standard' ? 'default' : 'outline'}
                   onClick={() => setDealType('standard')}
@@ -192,6 +208,14 @@ export const TalentAgencySystem: React.FC<TalentAgencySystemProps> = ({
                   onClick={() => setDealType('exclusive')}
                 >
                   Exclusive Contract
+                </Button>
+                <Button
+                  type="button"
+                  variant="link"
+                  className="h-auto px-0"
+                  onClick={() => openTalentProfile(selectedTalent.id)}
+                >
+                  View Profile
                 </Button>
               </div>
 

--- a/src/components/game/TalentProfileDialog.tsx
+++ b/src/components/game/TalentProfileDialog.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo } from 'react';
+import { useGameStore } from '@/game/store';
+import { useUiStore } from '@/game/uiStore';
+import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+
+const formatMoney = (amount: number) => `$${(amount / 1_000_000).toFixed(1)}M`;
+
+export const TalentProfileDialog: React.FC = () => {
+  const gameState = useGameStore((s) => s.game);
+  const talentProfileId = useUiStore((s) => s.talentProfileId);
+  const closeTalentProfile = useUiStore((s) => s.closeTalentProfile);
+
+  const talent = useMemo(() => {
+    if (!gameState || !talentProfileId) return null;
+    return gameState.talent.find(t => t.id === talentProfileId) || null;
+  }, [gameState, talentProfileId]);
+
+  const relationships = useMemo(() => {
+    if (!gameState || !talent || !talent.relationships) return [] as Array<{ id: string; name: string; type: string; note?: string }>;
+
+    return Object.entries(talent.relationships)
+      .map(([otherId, type]) => {
+        const other = gameState.talent.find(t => t.id === otherId);
+        return {
+          id: otherId,
+          name: other?.name || otherId,
+          type,
+          note: talent.relationshipNotes?.[otherId],
+        };
+      })
+      .slice(0, 12);
+  }, [gameState, talent]);
+
+  return (
+    <Dialog
+      open={!!talentProfileId}
+      onOpenChange={(open) => {
+        if (!open) closeTalentProfile();
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{talent ? talent.name : 'Talent Profile'}</DialogTitle>
+        </DialogHeader>
+
+        {!gameState || !talent ? (
+          <div className="text-sm text-muted-foreground">Talent not found.</div>
+        ) : (
+          <ScrollArea className="max-h-[70vh] pr-4">
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline" className="capitalize">{talent.type}</Badge>
+                <Badge variant="secondary">Rep: {Math.round(talent.reputation || 0)}/100</Badge>
+                {typeof talent.fame === 'number' && (
+                  <Badge variant="secondary">Fame: {Math.round(talent.fame)}/100</Badge>
+                )}
+                <Badge variant="outline">Age: {talent.age}</Badge>
+                <Badge variant="outline">Exp: {talent.experience}y</Badge>
+                <Badge variant="outline" className="capitalize">{talent.contractStatus}</Badge>
+                <Badge variant="secondary">Value: {formatMoney(talent.marketValue || 0)}</Badge>
+              </div>
+
+              {(talent.archetype || talent.biography) && (
+                <div className="space-y-1">
+                  {talent.archetype && (
+                    <p className="text-sm font-medium">{talent.archetype}</p>
+                  )}
+                  {talent.biography && (
+                    <p className="text-sm text-muted-foreground">{talent.biography}</p>
+                  )}
+                </div>
+              )}
+
+              {((talent.narratives || []).length > 0 || (talent.movementTags || []).length > 0) && (
+                <div className="space-y-2">
+                  {(talent.narratives || []).length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {(talent.narratives || []).slice(0, 10).map((n, i) => (
+                        <Badge key={i} variant="outline">{n}</Badge>
+                      ))}
+                    </div>
+                  )}
+                  {(talent.movementTags || []).length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {(talent.movementTags || []).slice(0, 10).map((t, i) => (
+                        <Badge key={i} variant="secondary">{t}</Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {(talent.traits || []).length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Traits</div>
+                  <div className="flex flex-wrap gap-2">
+                    {(talent.traits || []).slice(0, 12).map((t) => (
+                      <Badge key={t} variant="outline">{t}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {(talent.genres || []).length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-sm font-medium">Genres</div>
+                  <div className="flex flex-wrap gap-2">
+                    {(talent.genres || []).slice(0, 12).map((g) => (
+                      <Badge key={g} variant="secondary" className="capitalize">{g}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {(talent.awards || []).length > 0 && (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Awards</div>
+                    <div className="space-y-2">
+                      {(talent.awards || [])
+                        .slice()
+                        .sort((a: any, b: any) => (b.year || 0) - (a.year || 0))
+                        .slice(0, 8)
+                        .map((a: any, i: number) => (
+                          <div key={a.id || i} className="rounded border p-2 text-sm">
+                            <div className="font-medium">
+                              {(a.year ? `${a.year} ` : '') + (a.ceremony || 'Award')} — {a.category || 'Award'}
+                            </div>
+                            {(a.projectTitle || a.projectId) && (
+                              <div className="text-muted-foreground">{a.projectTitle || a.projectId}</div>
+                            )}
+                          </div>
+                        ))}
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {(talent.filmography || []).length > 0 && (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Filmography</div>
+                    <div className="space-y-2">
+                      {(talent.filmography || [])
+                        .slice()
+                        .sort((a, b) => (b.year || 0) - (a.year || 0))
+                        .slice(0, 12)
+                        .map((f) => (
+                          <div key={f.projectId} className="rounded border p-2 text-sm">
+                            <div className="font-medium">{f.year ? `${f.year} — ` : ''}{f.title}</div>
+                            <div className="text-muted-foreground">
+                              {f.role}
+                              {typeof f.boxOffice === 'number' ? ` • ${Math.round(f.boxOffice / 1_000_000)}M` : ''}
+                            </div>
+                          </div>
+                        ))}
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {relationships.length > 0 && (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Relationships</div>
+                    <div className="space-y-2">
+                      {relationships.map((r) => (
+                        <div key={r.id} className="rounded border p-2 text-sm">
+                          <div className="font-medium">{r.name} — {r.type}</div>
+                          {r.note && <div className="text-muted-foreground">{r.note}</div>}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          </ScrollArea>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/game/uiStore.ts
+++ b/src/game/uiStore.ts
@@ -6,6 +6,10 @@ export interface UiStoreState {
 
   selectedProjectId: string | null;
   setSelectedProjectId: (projectId: string | null) => void;
+
+  talentProfileId: string | null;
+  openTalentProfile: (talentId: string) => void;
+  closeTalentProfile: () => void;
 }
 
 export const useUiStore = create<UiStoreState>((set) => ({
@@ -14,4 +18,8 @@ export const useUiStore = create<UiStoreState>((set) => ({
 
   selectedProjectId: null,
   setSelectedProjectId: (projectId) => set({ selectedProjectId: projectId }),
+
+  talentProfileId: null,
+  openTalentProfile: (talentId) => set({ talentProfileId: talentId }),
+  closeTalentProfile: () => set({ talentProfileId: null }),
 }));


### PR DESCRIPTION
This PR revamps the lore/encyclopedia experience to remove actor bios and introduce TEW-style clickable profiles for talents, studios, franchises, and public domain IPs. It also wires up a dedicated TalentProfileDialog and UI store support to open profiles from various parts of the UI.

What changed
- LoreHub overhaul
  - Replaced the monolithic talent bios with modular two-pane encyclopedias:
    - StudioEncyclopedia: competitor studios with searchable list and detailed view
    - FranchiseEncyclopedia: franchises/IPs with richer detail and tags
    - PublicDomainEncyclopedia: public domain IPs with genre, flexibility, and core elements
  - Implemented a TwoPaneLayout to provide a TEW-style left list and right detail pane, with a search bar integrated into the list
  - Removed the TalentBiographySystem in favor of structured lore sections and data-driven cards
  - Replaced the previous talent-centric UI in LoreHub with these encyclopedia components and a unified, navigable experience

- Talent profiles (TEW-style clickable profiles)
  - Added TalentProfileDialog component to display a talent’s profile in a modal/dialog with:
    - Core attributes (type, rep, fame, age, experience, contract status, market value)
    - Biography, archetype, and narratives
    - Filmography, awards, and relationships (up to a cap for readability)
    - Traits and genres, with sections for core lore elements and relationships
  - Talent cards and list items now expose profile access via clickable names and a dedicated Profile button

- UI store integration for profiles
  - uiStore now includes talentProfileId, openTalentProfile, and closeTalentProfile
  - Multiple components use openTalentProfile(talent.id) to open profiles (e.g., CastingBoard, CastingRoleManager, TalentAgencySystem)
  - TalentProfileDialog listens to talentProfileId to control visibility and fetches talent data from game state

- Casting and legend adjustments
  - CastingBoard and CastingRoleManager updated to replace inline talent references with profile access points
  - Clicking a talent’s name or Profile button opens the TalentProfileDialog

- Data flow and type considerations
  - Added new encyclopedic view components and refactored LoreHub to assemble data from gameState into cohesive panels
  - TalentProfileDialog pulls talent and relationships from game state, and presents a structured, narrative-friendly view without relying on actor bios

How this solves the issue
- Removes actors/bios from the lore hub and introduces TEW-style clickable talent profiles for deeper storytelling without clutter
- Provides a clean, consistent, and clickable lore/encyclopedia experience across studios/franchises/public-domain IPs
- Centralizes talent exploration via TalentProfileDialog and a scalable two-pane encyclopedia layout

Notes
- Some UI details rely on existing Card, Tabs, Badge, and Dialog components; styling follows project conventions
- This is designed to be incremental; future data refinements can populate more fields in the encyclopedias and profiles.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/p92vedlf4e4b
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/64
Author: Evan Lewis