### PR TITLE
Fix JSX syntax error in CastingBoard.tsx by balancing div nesting

### DIFF
--- a/src/components/game/CastingBoard.tsx
+++ b/src/components/game/CastingBoard.tsx
@@ -319,6 +319,7 @@ export const CastingBoard: React.FC<CastingBoardProps> = ({
                       {talent.type}
                     </Badge>
                   </div>
+                </div>
                 <div className="text-right">
                   <div className="flex items-center space-x-1 text-sm text-muted-foreground">
                     <ReputationIcon size={14} />


### PR DESCRIPTION
Resolved a JSX syntax error in CastingBoard.tsx caused by an unbalanced div structure. A closing </div> was missing after the talent badge block, leading to the build error: 'Expected </, got jsx text' with Vite React SWC. The patch adds the missing closing tag to properly close the container before the subsequent right-aligned content, restoring valid JSX structure without altering styling or behavior.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/qb8mqva9q2vn
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/65
Author: Evan Lewis