### PR TITLE
Add smoke test for quick start and simplify game initialization to prevent blank screen on boot

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -17,3 +17,14 @@ test('can navigate to Help and back', async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole('button', { name: /^Quick Start$/ })).toBeVisible();
 });
+
+test('can quick start a new game', async ({ page }) => {
+  test.setTimeout(60_000);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: /^Quick Start$/ }).click();
+
+  // Once the game shell mounts, the top header includes a "Save Game" button.
+  // This guards against runtime errors during boot (e.g. blank screen after starting).
+  await expect(page.getByRole('button', { name: /^Save Game$/ })).toBeVisible({ timeout: 55_000 });
+});

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -493,12 +493,6 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
 
     const universeSeed = generateGameSeed();
 
-    // Start loading for game initialization
-    startOperation(LOADING_OPERATIONS.GAME_INIT.id, LOADING_OPERATIONS.GAME_INIT.name, LOADING_OPERATIONS.GAME_INIT.estimatedTime);
-    
-    // Initialize in steps with progress updates
-    updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 10, 'Setting up studio...');
-    
     const studio = {
       id: 'player-studio',
       name: gameConfig?.studioName || 'Untitled Pictures',
@@ -511,8 +505,6 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       weeksSinceLastProject: 0
     };
 
-    updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 30, 'Generating talent pool...');
-    
     // Initialize comprehensive talent pool
     const mods = getModBundle();
 
@@ -522,12 +514,8 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       (t) => t.id
     );
 
-    updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 60, 'Creating competitor studios...');
-    
     const studioGenerator = new StudioGenerator();
     const competitorStudios = studioGenerator.generateCompetitorStudios();
-
-    updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 80, 'Initializing systems...');
 
     let initialState: GameState = {
       universeSeed,
@@ -666,13 +654,6 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
     } catch (e) {
       console.warn('Failed to seed talent filmographies from AI releases', e);
     }
-
-    updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 100, 'Game ready!');
-    
-    // Complete initialization after a brief delay
-    setTimeout(() => {
-      completeOperation(LOADING_OPERATIONS.GAME_INIT.id);
-    }, 500);
 
     return initialState;
   });


### PR DESCRIPTION
- What this PR does:
  - Adds a smoke test that verifies starting a new game boots the game shell and exposes a Save Game button, guarding against blank-screen boot issues.
  - Simplifies the game initialization path by removing staged loading progress updates and the final completion timer in StudioMagnateGame, reducing potential race conditions during boot.

- Key changes:
  - e2e/smoke.spec.ts: Introduces test "can quick start a new game" which navigates to the app, clicks Quick Start, and asserts that a Save Game button is visible within a generous timeout. This helps catch scenarios where the start sequence renders but the initial screen does not load properly.
  - src/components/game/StudioMagnateGame.tsx: Removed the intermediate loading operation updates (10%, 30%, 60%, 80%, 100%) and the final completion timeout. The initialization now avoids the prior staged progress updates that could delay rendering or cause the blank screen on start.

- Why this fixes the issue:
  - The blank screen on start was tied to the boot sequence and its reliance on the staged loading progress logic. By removing those progress updates and the final completion timer, the game initialization becomes simpler and less prone to rendering races, allowing the game shell to mount reliably.
  - The new smoke test provides a regression guard to ensure a quick-start path boots successfully and that critical UI (Save Game) is present after startup.

- Notes:
  - No user-facing feature changes beyond stabilizing startup flow and adding a basic startup smoke test. Further tests can be added to cover saving, loading, and gameplay flow as needed.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/ph01kjf3x91l
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/73
Author: Evan Lewis