### PR TITLE
Refactor FranchiseGenerator to use static helpers and add favicon tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,13 +13,15 @@
       rel="stylesheet"
     />
 
+    <link rel="icon" type="image/x-icon" href="%BASE_URL%favicon.ico" />
+
     <meta property="og:title" content="Studio Magnate" />
     <meta property="og:description" content="The Ultimate Film Empire Simulator" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/favicon.ico" />
+    <meta property="og:image" content="%BASE_URL%favicon.ico" />
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:image" content="/favicon.ico" />
+    <meta name="twitter:image" content="%BASE_URL%favicon.ico" />
   </head>
 
   <body>

--- a/src/data/FranchiseGenerator.ts
+++ b/src/data/FranchiseGenerator.ts
@@ -165,7 +165,7 @@ export class FranchiseGenerator {
       usedSources.add(template.parodySource);
 
       const id = `FR${String(i + 1).padStart(3, '0')}`;
-      const originDate = this.generateRandomDate(2000, 2020, `${seed}|origin|${id}`);
+      const originDate = FranchiseGenerator.generateRandomDate(2000, 2020, `${seed}|origin|${id}`);
 
       const culturalWeight = template.culturalWeight + stableInt(`${seed}|cw|${id}`, -5, 4); // ±5 variation
 
@@ -188,7 +188,7 @@ export class FranchiseGenerator {
         cost: 0, // Will be calculated
       };
 
-      franchise.cost = this.calculateFranchiseCost(franchise);
+      franchise.cost = FranchiseGenerator.calculateFranchiseCost(franchise);
       franchises.push(franchise);
     }
 
@@ -196,7 +196,7 @@ export class FranchiseGenerator {
     while (franchises.length < count) {
       const id = `FR${String(franchises.length + 1).padStart(3, '0')}`;
       const randomTemplate = stablePick(FRANCHISE_TEMPLATES, `${seed}|template|${id}`) || FRANCHISE_TEMPLATES[0];
-      const title = this.generateRandomTitle(`${seed}|title|${id}`);
+      const title = FranchiseGenerator.generateRandomTitle(`${seed}|title|${id}`);
 
       if (usedTitles.has(title)) continue;
       usedTitles.add(title);
@@ -204,13 +204,13 @@ export class FranchiseGenerator {
       const franchise: Franchise = {
         id,
         title,
-        originDate: this.generateRandomDate(1990, 2022, `${seed}|origin|${id}`),
+        originDate: FranchiseGenerator.generateRandomDate(1990, 2022, `${seed}|origin|${id}`),
         creatorStudioId: `COMP_${stableInt(`${seed}|creator|${id}`, 1, 15)}`,
         genre: randomTemplate.genre,
         tone: randomTemplate.tone,
         entries: [],
         status: stableFloat01(`${seed}|status|${id}`) > 0.4 ? 'active' : 'dormant',
-        franchiseTags: this.generateRandomTags(`${seed}|tags|${id}`),
+        franchiseTags: FranchiseGenerator.generateRandomTags(`${seed}|tags|${id}`),
         culturalWeight: stableInt(`${seed}|cw|${id}`, 30, 69),
         merchandisingPotential: stableInt(`${seed}|merch|${id}`, 0, 99),
         fanbaseSize: stableInt(`${seed}|fanbase|${id}`, 0, 499_999),
@@ -219,7 +219,7 @@ export class FranchiseGenerator {
         cost: 0,
       };
 
-      franchise.cost = this.calculateFranchiseCost(franchise);
+      franchise.cost = FranchiseGenerator.calculateFranchiseCost(franchise);
       franchises.push(franchise);
     }
 

--- a/tests/franchiseGenerator.test.ts
+++ b/tests/franchiseGenerator.test.ts
@@ -11,4 +11,11 @@ describe('FranchiseGenerator', () => {
     const d = FranchiseGenerator.generateInitialFranchises(12, 'seed:test');
     expect(c).toEqual(d);
   });
+
+  it('generateInitialFranchises does not depend on this binding', () => {
+    const fn = FranchiseGenerator.generateInitialFranchises;
+
+    expect(() => fn.call({}, 5, 'seed:unbind')).not.toThrow();
+    expect(fn.call({}, 5, 'seed:unbind')).toHaveLength(5);
+  });
 });


### PR DESCRIPTION
This PR fixes a runtime error and improves asset loading by making helper methods static and updating favicon usage.

What changed:
- FranchiseGenerator.ts
  - Replaced instance method calls with static calls: FranchiseGenerator.calculateFranchiseCost, FranchiseGenerator.generateRandomDate, FranchiseGenerator.generateRandomTitle, FranchiseGenerator.generateRandomTags, etc.
  - This prevents binding issues (this) inside generateInitialFranchises and related code paths.
  - Updated tests to verify that generateInitialFranchises does not depend on a particular this binding.
- tests/franchiseGenerator.test.ts
  - Added a test to ensure FranchiseGenerator.generateInitialFranchises can be called without binding to an instance and still returns the expected number of franchises.
- index.html
  - Added favicon link: <link rel="icon" type="image/x-icon" href="%BASE_URL%favicon.ico" />
  - Updated og:image and twitter:image meta tags to reference %BASE_URL%favicon.ico for consistent social previews and to avoid 404s.

Rationale:
- The runtime error TypeError: this.calculateFranchiseCost is not a function was caused by this binding in a static-like usage path. Making helper methods static and updating all calls ensures no implicit this binding is required.
- Adding the favicon tag and updating social meta hrefs fixes the 404 favicon issue and ensures social previews load the correct icon."}]}```]

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/4ywiw5znfkqm
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/74
Author: Evan Lewis