### PR TITLE
Improve initial world generation: derive seeds, prime state, and retryable failure toast

### DIFF
--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -59,6 +59,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
 import type { TickRecapCard, TickReport, TickSystemReport } from '@/types/tickReport';
 import { createTickReport } from '@/utils/tickReport';
@@ -544,11 +545,28 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
     if (storeGameState) return;
     if (!initialGameState) return;
 
-    loadGameToStore(initialGameState, initialGameState.rngState ?? initialGameState.universeSeed);
+    const derivedUniverseSeed =
+      typeof initialGameState.universeSeed === 'number'
+        ? initialGameState.universeSeed
+        : seedFromString(`${initialGameState.studio?.id ?? 'studio'}`);
+
+    const derivedRngState =
+      typeof initialGameState.rngState === 'number'
+        ? initialGameState.rngState
+        : derivedUniverseSeed;
+
+    const primed = primeCompetitorTelevision({
+      ...initialGameState,
+      universeSeed: derivedUniverseSeed,
+      rngState: derivedRngState,
+    });
+
+    loadGameToStore(primed, primed.rngState ?? primed.universeSeed);
   }, [storeGameState, initialGameState, loadGameToStore]);
 
   // Generate a fresh world asynchronously so the loading overlay can appear immediately.
   const newGameInitStartedRef = useRef(false);
+  const [newGameInitAttempt, setNewGameInitAttempt] = useState(0);
 
   useEffect(() => {
     if (storeGameState) return;
@@ -862,7 +880,25 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
 
     run().catch((e) => {
       console.error('[Game Init] Failed to generate a new world', e);
+      newGameInitStartedRef.current = false;
       completeOperation(LOADING_OPERATIONS.GAME_INIT.id);
+
+      toast({
+        title: 'World Generation Failed',
+        description: 'Something went wrong while generating a new game world. You can retry without reloading the page.',
+        variant: 'destructive',
+        action: (
+          <ToastAction
+            altText="Retry"
+            onClick={() => {
+              newGameInitStartedRef.current = false;
+              setNewGameInitAttempt((n) => n + 1);
+            }}
+          >
+            Retry
+          </ToastAction>
+        ),
+      });
     });
 
     return () => {
@@ -872,11 +908,13 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
   }, [
     storeGameState,
     initialGameState,
+    newGameInitAttempt,
     gameConfig,
     startOperation,
     updateOperation,
     completeOperation,
     initGame,
+    toast,
   ]);
 
   const gameState = storeGameState ?? bootstrapGameState;


### PR DESCRIPTION
- Refined world start logic in StudioMagnateGame.tsx to deterministically derive seeds when not provided:
  - universeSeed is derived from initialGameState.universeSeed if a number, otherwise from seedFromString of the studio id (or 'studio' as fallback).
  - rngState is derived from initialGameState.rngState if a number, otherwise using the derived universe seed.
  - The initial game state is primed with primeCompetitorTelevision using the derived seeds, and then loaded via loadGameToStore.
- Added import for ToastAction and integrated a user-friendly retry mechanism on world generation failure:
  - Introduced newGameInitAttempt state and used it to retrigger initialization cycles.
  - On failure, display a destructive toast with a Retry action that resets the state and increments the retry counter.
- Wired the new retry counter into the effect dependencies to ensure a fresh attempt when requested.
- These changes align the startup behavior with TEW IX dev expectations by ensuring deterministic seed handling and providing a clear, retryable error path for world generation failures.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/bj2ycob4e3bo
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/81
Author: Evan Lewis