### PR TITLE
Fix initialization hang by yielding to the event loop with delay(0)

### DIFF
--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -580,7 +580,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       startOperation(LOADING_OPERATIONS.GAME_INIT.id, LOADING_OPERATIONS.GAME_INIT.name, LOADING_OPERATIONS.GAME_INIT.estimatedTime);
       updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 1, 'Preparing the world...');
 
-      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      await delay(0);
 
       const universeSeed = generateGameSeed();
 
@@ -623,7 +623,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       const totalWeeks = yearsToSeed.length * 52;
       let processedWeeks = 0;
 
-      const yieldToBrowser = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      const yieldToBrowser = () => delay(0);
       const YIELD_EVERY_OPS = 25;
       let processedOps = 0;
 
@@ -859,7 +859,7 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
           if (i % 25 === 0) {
             const p = 88 + (i / Math.max(1, total)) * 10;
             updateOperation(LOADING_OPERATIONS.GAME_INIT.id, Math.min(98, Math.round(p)), `Seeding filmographies... (${i}/${total})`);
-            await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            await delay(0);
           }
         }
 
@@ -873,9 +873,9 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
       updateOperation(LOADING_OPERATIONS.GAME_INIT.id, 100, 'Finalizing...');
       initGame(initialState, initialState.universeSeed);
 
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         completeOperation(LOADING_OPERATIONS.GAME_INIT.id);
-      });
+      }, 0);
     };
 
     run().catch((e) => {


### PR DESCRIPTION
Problem: initialization could stall due to using requestAnimationFrame-wrapped promises in non-UI contexts, which could block subsequent steps during game init.

What changed:
- StudioMagnateGame.tsx:
  - After starting GAME_INIT, replaced await new Promise<void>((resolve) => requestAnimationFrame(() => resolve())) with await delay(0).
  - Updated yieldToBrowser to return delay(0) instead of a requestAnimationFrame-based promise.
  - Inside the seeding loop, replaced the per-25-iteration yield with await delay(0) (instead of awaiting requestAnimationFrame).
  - In the finalization step, replaced the requestAnimationFrame callback with setTimeout(() => { completeOperation(...); }, 0) to defer completion to the next tick.

Impact:
- Yields control to the browser across initialization steps, preventing potential hangs and improving responsiveness of the loading UI during world generation and setup.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/qrtmu9sh6nzq
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/82
Author: Evan Lewis