### PR TITLE
Escape arrow characters in UI text to fix JSX parsing errors in OnlineLeague and SupabaseConfigDialog

### DIFF
--- a/src/components/game/OnlineLeague.tsx
+++ b/src/components/game/OnlineLeague.tsx
@@ -526,7 +526,7 @@ export const OnlineLeague: React.FC<OnlineLeagueProps> = ({ initialLeagueCode })
               Online League requires Supabase settings.
             </p>
             <p>
-              If you’re running the desktop app, configure it from the main menu (Online -> Configure…). If you’re developing locally, you can also set <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> in <code>.env</code>.
+              If you’re running the desktop app, configure it from the main menu (Online -{'>'} Configure…). If you’re developing locally, you can also set <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> in <code>.env</code>.
             </p>
           </CardContent>
         </Card>

--- a/src/components/game/SupabaseConfigDialog.tsx
+++ b/src/components/game/SupabaseConfigDialog.tsx
@@ -104,7 +104,7 @@ export function SupabaseConfigDialog(props: { open: boolean; onOpenChange: (open
               type="password"
             />
             <div className="text-xs text-muted-foreground">
-              This is the public anon key from your Supabase project (Settings -> API).
+              This is the public anon key from your Supabase project (Settings -{'>'} API).
             </div>
           </div>
         </div>


### PR DESCRIPTION
During lint, parsing errors were reported in two files due to using a plain '>' in JSX text. Replaced the arrow sequences with a JSX-escaped form using -{'>'} to render a literal greater-than symbol. Specific changes:
- OnlineLeague.tsx: change 'Online -> Configure…' to 'Online -{'>'} Configure…'
- SupabaseConfigDialog.tsx: change 'Settings -> API' to 'Settings -{'>'} API'
This resolves the parsing errors without changing behavior or UI semantics. No other changes were made.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/8diqro4nnv2l
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/100
Author: Evan Lewis