### PR TITLE
Studio Magnate: Normalize Vite base path to prevent module import failures

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,20 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+function normalizeBase(base: string): string {
+  const trimmed = base.trim();
+  if (trimmed.length === 0) {
+    return "/";
+  }
+
+  if (trimmed === "/" || trimmed === "./") {
+    return trimmed;
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -13,13 +27,15 @@ export default defineConfig(({ mode }) => {
       : `/${repoName}/`
     : null;
 
-  const base = (process.env.VITE_BASE && process.env.VITE_BASE.length > 0)
-    ? process.env.VITE_BASE
-    : (env.VITE_BASE && env.VITE_BASE.length > 0)
-      ? env.VITE_BASE
+  const configuredBase = (env.VITE_BASE && env.VITE_BASE.length > 0)
+    ? env.VITE_BASE
+    : (process.env.VITE_BASE && process.env.VITE_BASE.length > 0)
+      ? process.env.VITE_BASE
       : (process.env.GITHUB_ACTIONS === "true" && mode === "production" && ghPagesBase)
         ? ghPagesBase
         : "/";
+
+  const base = normalizeBase(configuredBase);
 
   return {
     base,


### PR DESCRIPTION
Adds a normalization helper for Vite's base path and applies it to the final base value.

What changed:
- Introduced normalizeBase in vite.config.ts to standardize base paths:
  - Trims whitespace, treats empty as "/";
  - Leaves "/" and "./" as-is;
  - Ensures a leading slash and a trailing slash for consistency.
- Centralized base calculation via configuredBase and then applied normalizeBase(configuredBase) to produce the final base value.
- Keeps existing ghPagesBase fallback and env-based overrides intact.

Why:
- The crash (TypeError: Importing a module script failed) can occur when the Vite base is inconsistent or malformed across environments (local, GitHub Actions, GH Pages). Normalizing the base ensures module/script URLs resolve correctly, preventing import failures in production.

Impact:
- No public API changes. Only the build configuration logic was updated to produce a robust base path.
- Production builds (including GH Pages) should be more stable when loading modules and assets.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/xqh9p8qm0qz7
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/101
Author: Evan Lewis