### PR TITLE
Studio Magnate: Add crash diagnostics and automatic chunk-load recovery

### DIFF
--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { attemptChunkLoadRecovery, isChunkLoadError } from '@/utils/chunkLoadRecovery';
 
 type Props = {
   children: React.ReactNode;
@@ -33,6 +34,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('Unhandled UI error', error, info);
+
+    if (import.meta.env.PROD && isChunkLoadError(error)) {
+      attemptChunkLoadRecovery({ maxAttemptsPerSession: 1 });
+    }
   }
 
   private reset = () => {
@@ -58,6 +63,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     }
 
     const error = this.state.error;
+    const chunkLoadError = isChunkLoadError(error);
 
     return (
       <div className="p-6">
@@ -67,7 +73,9 @@ export class ErrorBoundary extends React.Component<Props, State> {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="text-sm text-muted-foreground">
-              The game encountered an unexpected error. You can try reloading.
+              {chunkLoadError
+                ? 'An update may have been deployed while this tab was open. Reload to fetch the latest version.'
+                : 'The game encountered an unexpected error. You can try reloading.'}
             </div>
 
             {import.meta.env.DEV && (
@@ -80,6 +88,11 @@ export class ErrorBoundary extends React.Component<Props, State> {
               <Button onClick={() => window.location.reload()}>
                 Reload
               </Button>
+              {chunkLoadError && (
+                <Button variant="secondary" onClick={() => attemptChunkLoadRecovery({ maxAttemptsPerSession: 1 })}>
+                  Reload (force update)
+                </Button>
+              )}
               <Button variant="outline" onClick={() => window.location.assign(import.meta.env.BASE_URL || '/')}>
                 Return to main menu
               </Button>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,9 @@ import App from './App.tsx';
 import './index.css';
 import { applyProductionConsolePolicy } from '@/utils/consolePolicy';
 import { initUiSkin } from '@/utils/uiSkins';
+import { installVitePreloadErrorHandler } from '@/utils/chunkLoadRecovery';
 
+installVitePreloadErrorHandler();
 applyProductionConsolePolicy();
 initUiSkin();
 

--- a/src/utils/chunkLoadRecovery.ts
+++ b/src/utils/chunkLoadRecovery.ts
@@ -1,0 +1,74 @@
+const RECOVERY_SESSION_KEY = 'sm:chunk-load-recovery-attempts';
+
+export function isChunkLoadErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+
+  return (
+    normalized.includes('importing a module script failed') ||
+    normalized.includes('failed to fetch dynamically imported module') ||
+    normalized.includes('error loading dynamically imported module') ||
+    normalized.includes('import() failed') ||
+    (normalized.includes('loading chunk') && normalized.includes('failed'))
+  );
+}
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const message = 'message' in error && typeof (error as { message?: unknown }).message === 'string'
+    ? (error as { message: string }).message
+    : '';
+
+  return isChunkLoadErrorMessage(message);
+}
+
+export function buildCacheBustedUrl(href: string, token: string = String(Date.now())): string {
+  const url = new URL(href);
+  url.searchParams.set('__sm_reload', token);
+  return url.toString();
+}
+
+export function attemptChunkLoadRecovery(options?: { maxAttemptsPerSession?: number }): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const maxAttemptsPerSession = options?.maxAttemptsPerSession ?? 1;
+  let attempts = 0;
+
+  try {
+    attempts = Number(window.sessionStorage.getItem(RECOVERY_SESSION_KEY) || '0');
+  } catch {
+    attempts = 0;
+  }
+
+  if (attempts >= maxAttemptsPerSession) {
+    return false;
+  }
+
+  try {
+    window.sessionStorage.setItem(RECOVERY_SESSION_KEY, String(attempts + 1));
+  } catch {
+    // Ignore session storage failures (private mode / storage disabled).
+  }
+
+  const href = (() => {
+    try {
+      return buildCacheBustedUrl(window.location.href);
+    } catch {
+      return window.location.href;
+    }
+  })();
+
+  window.location.replace(href);
+  return true;
+}
+
+export function installVitePreloadErrorHandler(): void {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener('vite:preloadError', (event) => {
+    const didAttempt = attemptChunkLoadRecovery({ maxAttemptsPerSession: 1 });
+    if (didAttempt) {
+      event.preventDefault();
+    }
+  });
+}

--- a/tests/chunkLoadRecovery.test.ts
+++ b/tests/chunkLoadRecovery.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { attemptChunkLoadRecovery, buildCacheBustedUrl, isChunkLoadErrorMessage } from '@/utils/chunkLoadRecovery';
+
+describe('chunkLoadRecovery', () => {
+  it('detects common chunk/module import error messages', () => {
+    expect(isChunkLoadErrorMessage('Importing a module script failed.')).toBe(true);
+    expect(isChunkLoadErrorMessage('Failed to fetch dynamically imported module: https://x/y.js')).toBe(true);
+    expect(isChunkLoadErrorMessage('Error loading dynamically imported module: /assets/chunk.js')).toBe(true);
+    expect(isChunkLoadErrorMessage('Something else')).toBe(false);
+  });
+
+  it('adds a cache-busting query param', () => {
+    expect(buildCacheBustedUrl('https://example.com/app', '123')).toBe('https://example.com/app?__sm_reload=123');
+    expect(buildCacheBustedUrl('https://example.com/app?x=1', '123')).toBe('https://example.com/app?x=1&__sm_reload=123');
+  });
+
+  describe('attemptChunkLoadRecovery', () => {
+    const originalWindow = globalThis.window;
+
+    afterEach(() => {
+      (globalThis as any).window = originalWindow;
+      vi.restoreAllMocks();
+    });
+
+    beforeEach(() => {
+      const store = new Map<string, string>();
+
+      (globalThis as any).window = {
+        sessionStorage: {
+          getItem: (key: string) => store.get(key) ?? null,
+          setItem: (key: string, value: string) => {
+            store.set(key, value);
+          },
+        },
+        location: {
+          href: 'https://example.com/app',
+          replace: vi.fn(),
+        },
+        addEventListener: vi.fn(),
+      };
+    });
+
+    it('replaces location once per session', () => {
+      const didAttempt = attemptChunkLoadRecovery({ maxAttemptsPerSession: 1 });
+      expect(didAttempt).toBe(true);
+
+      const didAttemptAgain = attemptChunkLoadRecovery({ maxAttemptsPerSession: 1 });
+      expect(didAttemptAgain).toBe(false);
+
+      const replace = (globalThis.window as any).location.replace as ReturnType<typeof vi.fn>;
+      expect(replace).toHaveBeenCalledTimes(1);
+
+      const firstUrl = replace.mock.calls[0][0];
+      expect(String(firstUrl)).toContain('__sm_reload=');
+    });
+  });
+});


### PR DESCRIPTION
- Introduced chunkLoadRecovery utilities to detect and recover from dynamic import / chunk-load errors.
- Added isChunkLoadErrorMessage and isChunkLoadError to reliably identify module/script loading failures.
- Implemented buildCacheBustedUrl to force re-fetch of updated chunks via a cache-busting query param.
- Implemented attemptChunkLoadRecovery with per-session caps and safe storage handling to trigger a page reload with a cache-busted URL.
- Added installVitePreloadErrorHandler to respond to Vite preload errors and automatically attempt recovery.
- Wired recovery into the UI: ErrorBoundary now detects chunk-load errors, shows a tailored message, and offers a "Reload (force update)" option that triggers recovery.
- On production, ErrorBoundary triggers an automatic recovery attempt when a chunk-load error is caught.
- main.tsx now initializes the Vite preload error handler at startup.
- Added unit tests (tests/chunkLoadRecovery.test.ts) to verify error detection, URL tampering, and single-attempt recovery behavior.
- This change addresses crash scenarios caused by import() failures and Nvidia-like cache/version drift by ensuring users can recover with minimal friction and up-to-date assets.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/066nbu9jiuf8
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/102
Author: Evan Lewis