### PR TITLE
Gate Launch Platform button behind canLaunchPlatform flag to support debugging bypass

### DIFF
--- a/src/components/game/StreamingWarsPlatformApp.tsx
+++ b/src/components/game/StreamingWarsPlatformApp.tsx
@@ -711,7 +711,7 @@ export const StreamingWarsPlatformApp: React.FC = () => {
                     ensureLaunchDefaults();
                     setLaunchOpen(true);
                   }}
-                  disabled={!hasEnoughBudget || !hasEnoughReputation || !hasEnoughReleases}
+                  disabled={!canLaunchPlatform}
                 >
                   Launch Platform
                 </Button>


### PR DESCRIPTION
This change updates the Launch Platform button in StreamingWarsPlatformApp to be gated by a single canLaunchPlatform flag instead of multiple prerequisites (budget, reputation, releases). This makes it straightforward to bypass the gating during debugging by overriding canLaunchPlatform, aligning with the intention to speed up development when you don’t yet own a platform or have all prerequisites.

What changed:
- The disabled state of the Launch Platform button now uses canLaunchPlatform instead of individual booleans.
- Preserves the existing flow (ensureLaunchDefaults and opening the launch modal) when the button is enabled.

How to test:
- In debug mode, set canLaunchPlatform to true and verify the button enables and opens the launch modal.
- In production/general use, ensure the button remains disabled until canLaunchPlatform evaluates to true based on the underlying prerequisites.

This patch makes it easier to bypass launch gating during development without changing the core launch logic.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/o31u6nmpfb0l
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/121
Author: Evan Lewis