### PR TITLE
Add window size presets, persistence, and scrolling fixes for large screens

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -33,4 +33,5 @@ test('can quick start a new game', async ({ page }) => {
   await page.getByRole('button', { name: /^Settings$/ }).click();
   await expect(page.getByRole('heading', { name: /^Settings$/ })).toBeVisible();
   await expect(page.getByText(/^UI Skin$/)).toBeVisible();
+  await expect(page.getByText(/^Window Size$/)).toBeVisible();
 });

--- a/src/components/game/GameSettingsDialog.tsx
+++ b/src/components/game/GameSettingsDialog.tsx
@@ -13,13 +13,26 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { getStoredUiSkinId, setUiSkin, UI_SKINS, type UiSkinId } from '@/utils/uiSkins';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  applyWindowSizePreset,
+  getStoredWindowSizePresetId,
+  setStoredWindowSizePresetId,
+  WINDOW_SIZE_PRESETS,
+  type WindowSizePresetId,
+} from '@/utils/windowSize';
+import { isTauriRuntime } from '@/integrations/tauri/saves';
 
 export function GameSettingsDialog(props: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const [uiSkin, setUiSkinState] = useState<UiSkinId>(() => getStoredUiSkinId());
+  const [windowSizePreset, setWindowSizePreset] = useState<WindowSizePresetId>(() => getStoredWindowSizePresetId());
+
+  const canResizeWindow = useMemo(() => isTauriRuntime(), []);
 
   useEffect(() => {
     if (!props.open) return;
     setUiSkinState(getStoredUiSkinId());
+    setWindowSizePreset(getStoredWindowSizePresetId());
   }, [props.open]);
 
   const activeSkin = useMemo(() => UI_SKINS.find((s) => s.id === uiSkin) ?? UI_SKINS[0], [uiSkin]);
@@ -29,12 +42,20 @@ export function GameSettingsDialog(props: { open: boolean; onOpenChange: (open: 
     setUiSkinState(skinId);
   };
 
+  const handleWindowSizeApply = () => {
+    setStoredWindowSizePresetId(windowSizePreset);
+    if (!canResizeWindow) return;
+    void applyWindowSizePreset(windowSizePreset).catch((err) => {
+      console.warn('[windowSize] Failed to apply preset', err);
+    });
+  };
+
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent className="max-w-3xl card-premium">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
-          <DialogDescription>UI changes apply instantly and persist across sessions.</DialogDescription>
+          <DialogDescription>Changes persist across sessions.</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -98,6 +119,41 @@ export function GameSettingsDialog(props: { open: boolean; onOpenChange: (open: 
                   </div>
                 </button>
               ))}
+            </div>
+          </div>
+
+          <div className="rounded-md border border-border/60 bg-background/40 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <div className="text-sm font-semibold text-foreground">Window Size</div>
+                <div className="text-xs text-muted-foreground">Common screen sizes (desktop only).</div>
+              </div>
+              <Button size="sm" variant="secondary" onClick={handleWindowSizeApply} disabled={!canResizeWindow}>
+                Apply
+              </Button>
+            </div>
+
+            <Separator className="my-3 bg-border/60" />
+
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+              <Select value={windowSizePreset} onValueChange={(v) => setWindowSizePreset(v as WindowSizePresetId)}>
+                <SelectTrigger className="w-[280px]">
+                  <SelectValue placeholder="Choose a size" />
+                </SelectTrigger>
+                <SelectContent>
+                  {WINDOW_SIZE_PRESETS.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {!canResizeWindow && (
+                <div className="text-xs text-muted-foreground">
+                  Not available in the browser build (resize your window instead).
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 overscroll-contain data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 overscroll-contain data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[calc(100vh-6rem)] h-auto flex-col overflow-y-auto rounded-t-[10px] border bg-background",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -29,13 +29,13 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 overflow-y-auto bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 max-h-[90vh] border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          "inset-x-0 bottom-0 max-h-[90vh] border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
           "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,9 +4,13 @@ import './index.css';
 import { applyProductionConsolePolicy } from '@/utils/consolePolicy';
 import { initUiSkin } from '@/utils/uiSkins';
 import { installVitePreloadErrorHandler } from '@/utils/chunkLoadRecovery';
+import { applyStoredWindowSizePreset } from '@/utils/windowSize';
 
 installVitePreloadErrorHandler();
 applyProductionConsolePolicy();
 initUiSkin();
+void applyStoredWindowSizePreset().catch((err) => {
+  console.warn('[windowSize] Failed to apply stored preset', err);
+});
 
 createRoot(document.getElementById('root')!).render(<App />);

--- a/src/utils/windowSize.ts
+++ b/src/utils/windowSize.ts
@@ -1,0 +1,74 @@
+import { isTauriRuntime } from '@/integrations/tauri/saves';
+
+export type WindowSizePresetId =
+  | 'auto'
+  | '1024x768'
+  | '1280x720'
+  | '1280x800'
+  | '1366x768'
+  | '1440x900'
+  | '1600x900'
+  | '1920x1080'
+  | '2560x1440';
+
+export type WindowSizePreset = {
+  id: WindowSizePresetId;
+  label: string;
+  width?: number;
+  height?: number;
+};
+
+export const WINDOW_SIZE_PRESETS: WindowSizePreset[] = [
+  { id: 'auto', label: 'Auto (don\'t force)' },
+  { id: '1024x768', label: '1024 × 768 (XGA)', width: 1024, height: 768 },
+  { id: '1280x720', label: '1280 × 720 (HD)', width: 1280, height: 720 },
+  { id: '1280x800', label: '1280 × 800 (WXGA / Steam Deck)', width: 1280, height: 800 },
+  { id: '1366x768', label: '1366 × 768 (Laptop)', width: 1366, height: 768 },
+  { id: '1440x900', label: '1440 × 900 (MacBook)', width: 1440, height: 900 },
+  { id: '1600x900', label: '1600 × 900 (HD+)', width: 1600, height: 900 },
+  { id: '1920x1080', label: '1920 × 1080 (Full HD)', width: 1920, height: 1080 },
+  { id: '2560x1440', label: '2560 × 1440 (QHD)', width: 2560, height: 1440 },
+];
+
+const STORAGE_KEY = 'studio-magnate-window-size';
+
+export function normalizeWindowSizePresetId(raw: string | null | undefined): WindowSizePresetId {
+  const v = (raw ?? '').trim() as WindowSizePresetId;
+  if (WINDOW_SIZE_PRESETS.some((p) => p.id === v)) return v;
+  return 'auto';
+}
+
+export function getStoredWindowSizePresetId(): WindowSizePresetId {
+  if (typeof window === 'undefined') return 'auto';
+  return normalizeWindowSizePresetId(window.localStorage.getItem(STORAGE_KEY));
+}
+
+export function setStoredWindowSizePresetId(id: WindowSizePresetId) {
+  if (typeof window === 'undefined') return;
+
+  if (id === 'auto') {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, id);
+}
+
+export async function applyStoredWindowSizePreset(): Promise<void> {
+  if (!isTauriRuntime()) return;
+
+  const presetId = getStoredWindowSizePresetId();
+  if (presetId === 'auto') return;
+
+  await applyWindowSizePreset(presetId);
+}
+
+export async function applyWindowSizePreset(presetId: WindowSizePresetId): Promise<void> {
+  if (!isTauriRuntime()) return;
+
+  const preset = WINDOW_SIZE_PRESETS.find((p) => p.id === presetId);
+  if (!preset?.width || !preset?.height) return;
+
+  const { getCurrentWindow, LogicalSize } = await import('@tauri-apps/api/window');
+  await getCurrentWindow().setSize(new LogicalSize(preset.width, preset.height));
+}


### PR DESCRIPTION
Summary:
- Introduced window size presets and persistence for desktop/Tauri runtime, enabling users to select common window sizes and apply them from Settings.
- Persisted selected window size across sessions and auto-apply on app startup.
- Improved UI scrolling for long dialogs/sheets/drawers to prevent overflow on small screens.

What changed:
- New: src/utils/windowSize.ts
  - WindowSizePresetId type with presets (auto, 1024x768, 1280x720, 1280x800, 1366x768, 1440x900, 1600x900, 1920x1080, 2560x1440).
  - WINDOW_SIZE_PRESETS array with labels and dimensions.
  - getStoredWindowSizePresetId / setStoredWindowSizePresetId for localStorage persistence (auto stored as removal when not needed).
  - applyStoredWindowSizePreset and applyWindowSizePreset to resize the app window (TAURI only).
  - normalizeWindowSizePresetId helper for safe parsing.
- New: src/components/game/GameSettingsDialog.tsx
  - Added window size UI: a Select to choose a preset and an Apply button.
  - State for windowSizePreset and logic to persist and apply presets when possible.
  - Show availability message when running outside TAURI (browser builds).
  - Minor wording change in description.
- Updated: src/main.tsx
  - On startup, applyStoredWindowSizePreset to apply any saved window size preset automatically.
- Updated: src/components/ui/dialog.tsx and related components
  - Dialog and content wrappers updated to allow scrolling when content overflows by adding max-h-[90vh] and overflow-y-auto where appropriate (improves handling for long modals).
- Updated: src/components/ui/alert-dialog.tsx, src/components/ui/drawer.tsx, src/components/ui/sheet.tsx
  - Ensure large panels (alerts, drawers, sheets) support vertical overflow and stay within 90% viewport height.
- Updated: e2e/smoke.spec.ts
  - Test now verifies that the Settings screen shows a Window Size option (Window Size appears in Settings).

Why this solves the issue:
- Users can now pick from common screen sizes to avoid oversized, hard-to-navigate dialogs on smaller screens. The window is resized only on TAURI runtime, as browser environments don’t expose window sizing. Preserving this setting across sessions reduces friction when returning to the app.
- Long dialogs, popups, and sheets no longer overflow off-screen; content becomes scrollable within a 90vh cap, improving accessibility on small devices.

Notes:
- The new Window Size controls are visible in Settings and are persisted via localStorage (non-TAURI environments won’t resize; the Apply button is disabled in those cases).
- The startup behavior now respects a previously saved size automatically, ensuring a consistent user experience after reloads.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/tlrct0obsq6t
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/124
Author: Evan Lewis