### PR TITLE
Use dynamic platform name for hub label in StreamingPlatformPreview

### DIFF
--- a/src/components/game/StreamingPlatformPreview.tsx
+++ b/src/components/game/StreamingPlatformPreview.tsx
@@ -462,7 +462,7 @@ export const StreamingPlatformPreview: React.FC<{
               }}
               data-active={prestigeView === 'browse' && activeNav === 'home'}
             >
-              <div className="sp-hub-label">HBO</div>
+              <div className="sp-hub-label">{platformName}</div>
               <div className="sp-hub-sub">Originals + favorites</div>
             </button>
             <button


### PR DESCRIPTION
Fix: Replace the hardcoded 'HBO' label with a dynamic platformName in StreamingPlatformPreview so the hub label reflects the actual platform instead of always showing HBO. This resolves the prestige app theme issue where HBO was shown regardless of the selected platform. The change is limited to the label rendering; no other behavior was modified, and platformName is already available in the component as the label source.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/hld4dy8a9wp6
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/134
Author: Evan Lewis