### PR TITLE
Support GitHub Actions Variables for itch release config and add input validation

### DIFF
--- a/.github/workflows/itch-release.yml
+++ b/.github/workflows/itch-release.yml
@@ -114,20 +114,24 @@ jobs:
 
       - name: Setup butler
         uses: remarkablegames/setup-butler@v2
-        env:
-          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
 
       - name: Upload to itch.io
         shell: bash
         env:
-          ITCH_USERNAME: ${{ secrets.ITCH_USERNAME }}
-          ITCH_GAME: ${{ secrets.ITCH_GAME }}
+          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+          ITCH_USERNAME: ${{ secrets.ITCH_USERNAME || vars.ITCH_USERNAME }}
+          ITCH_GAME: ${{ secrets.ITCH_GAME || vars.ITCH_GAME }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
 
+          if [ -z "${BUTLER_API_KEY:-}" ]; then
+            echo "BUTLER_API_KEY must be configured as a GitHub Secret." >&2
+            exit 1
+          fi
+
           if [ -z "${ITCH_USERNAME:-}" ] || [ -z "${ITCH_GAME:-}" ]; then
-            echo "ITCH_USERNAME and ITCH_GAME must be configured as GitHub Secrets." >&2
+            echo "ITCH_USERNAME and ITCH_GAME must be configured as GitHub Secrets or Actions Variables." >&2
             exit 1
           fi
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -48,7 +48,7 @@ npm run tauri:build
 
 See: `scripts/itch/README.md`
 
-- [ ] Configure GitHub Secrets (`BUTLER_API_KEY`, `ITCH_USERNAME`, `ITCH_GAME`) if using CI
+- [ ] Configure GitHub Secrets/Variables (`BUTLER_API_KEY` secret; `ITCH_USERNAME`/`ITCH_GAME` secret or variable) if using CI
 - [ ] Upload builds either:
   - [ ] via GitHub Actions: run `itch-release` (manual) or push a `v*` tag, or
   - [ ] locally using `butler push` (or `scripts/itch/upload.ps1`)

--- a/scripts/itch/README.md
+++ b/scripts/itch/README.md
@@ -9,11 +9,11 @@ This repo supports itch.io uploads either:
 
 ### 1) Configure repo secrets
 
-Add the following GitHub Secrets:
+Add the following GitHub Secrets (or Variables where noted):
 
-- `BUTLER_API_KEY` (itch.io API key)
-- `ITCH_USERNAME` (your itch.io username)
-- `ITCH_GAME` (your itch.io project slug, e.g. `studio-magnate`)
+- `BUTLER_API_KEY` (**Secret**; itch.io API key)
+- `ITCH_USERNAME` (Secret or Variable; your itch.io username)
+- `ITCH_GAME` (Secret or Variable; your itch.io project slug, e.g. `studio-magnate`)
 
 ### 2) Trigger the workflow
 


### PR DESCRIPTION
This PR updates the itch.io release workflow to support using GitHub Actions Variables as fallbacks for itch release configuration, and adds validation messages to fail fast with clear guidance. 

What changed:
- .github/workflows/itch-release.yml
  - Upload to itch.io now pulls BUTLER_API_KEY from secrets and ITCH_USERNAME/ITCH_GAME from secrets or Actions Variables.
  - Added a pre-check to ensure BUTLER_API_KEY is configured (as a secret).
  - If ITCH_USERNAME or ITCH_GAME is missing, the workflow errors with a message that they must be configured as Secrets or Variables.

- RELEASE_CHECKLIST.md
  - Updated to reflect that ITCH_USERNAME and ITCH_GAME can be provided via Secrets or Variables (and that BUTLER_API_KEY must be a Secret).

- scripts/itch/README.md
  - Clarified setup instructions: add BUTLER_API_KEY as a Secret; ITCH_USERNAME and ITCH_GAME can be provided as Secrets or Variables.

Impact:
- Improves flexibility by allowing CI to use Actions Variables in addition to Secrets for itch release configuration.
- Provides clearer validation and error messages to diagnose missing configuration quickly.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/50hd20caeeqp
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/135
Author: Evan Lewis