### PR TITLE
Add robust, safe cloning for media state hydration to handle non-cloneable values

### DIFF
--- a/src/game/media/mediaEngine.ts
+++ b/src/game/media/mediaEngine.ts
@@ -6,11 +6,97 @@ import { stableFloat01, stableInt } from '@/utils/stableRandom';
 import { isPrimaryStreamingFilm, isTvProject } from '@/utils/projectMedium';
 import { current, isDraft } from 'immer';
 
+function isDomLike(value: unknown): boolean {
+  const g = globalThis as any;
+  if (!value || typeof value !== 'object') return false;
+
+  const NodeCtor = g.Node as (new (...args: any[]) => any) | undefined;
+  if (typeof NodeCtor === 'function' && value instanceof NodeCtor) return true;
+
+  const EventCtor = g.Event as (new (...args: any[]) => any) | undefined;
+  if (typeof EventCtor === 'function' && value instanceof EventCtor) return true;
+
+  const WindowCtor = g.Window as (new (...args: any[]) => any) | undefined;
+  if (typeof WindowCtor === 'function' && value instanceof WindowCtor) return true;
+
+  return false;
+}
+
+function fallbackClone<T>(value: T): T {
+  const seen = new WeakMap<object, any>();
+
+  const walk = (v: any): any => {
+    if (v === null || v === undefined) return v;
+
+    const t = typeof v;
+    if (t === 'string' || t === 'number' || t === 'boolean') return v;
+    if (t === 'bigint') return Number(v);
+    if (t === 'symbol' || t === 'function') return undefined;
+
+    if (isDomLike(v)) return undefined;
+
+    if (v instanceof Date) return new Date(v.getTime());
+
+    if (t !== 'object') return undefined;
+
+    if (seen.has(v)) return seen.get(v);
+
+    if (Array.isArray(v)) {
+      const out: any[] = [];
+      seen.set(v, out);
+      for (const item of v) {
+        const next = walk(item);
+        if (next !== undefined) out.push(next);
+      }
+      return out;
+    }
+
+    if (v instanceof Map) {
+      const out = new Map();
+      seen.set(v, out);
+      for (const [k, val] of v.entries()) {
+        const nk = walk(k);
+        const nv = walk(val);
+        if (nk !== undefined && nv !== undefined) out.set(nk, nv);
+      }
+      return out;
+    }
+
+    if (v instanceof Set) {
+      const out = new Set();
+      seen.set(v, out);
+      for (const item of v.values()) {
+        const next = walk(item);
+        if (next !== undefined) out.add(next);
+      }
+      return out;
+    }
+
+    const out: Record<string, any> = {};
+    seen.set(v, out);
+
+    for (const [k, val] of Object.entries(v)) {
+      const next = walk(val);
+      if (next !== undefined) out[k] = next;
+    }
+
+    return out;
+  };
+
+  return walk(value) as T;
+}
+
 function clone<T>(value: T): T {
-  if (typeof (globalThis as any).structuredClone === 'function') {
-    return (globalThis as any).structuredClone(value);
+  const sc = (globalThis as any).structuredClone as ((input: any) => any) | undefined;
+  if (typeof sc === 'function') {
+    try {
+      return sc(value);
+    } catch {
+      return fallbackClone(value);
+    }
   }
-  return JSON.parse(JSON.stringify(value)) as T;
+
+  return fallbackClone(value);
 }
 
 class MediaEngine {

--- a/src/game/media/mediaResponseSystem.ts
+++ b/src/game/media/mediaResponseSystem.ts
@@ -3,11 +3,97 @@ import { MediaEngine } from './mediaEngine';
 import { stableFloat01, stableInt } from '@/utils/stableRandom';
 import { current, isDraft } from 'immer';
 
+function isDomLike(value: unknown): boolean {
+  const g = globalThis as any;
+  if (!value || typeof value !== 'object') return false;
+
+  const NodeCtor = g.Node as (new (...args: any[]) => any) | undefined;
+  if (typeof NodeCtor === 'function' && value instanceof NodeCtor) return true;
+
+  const EventCtor = g.Event as (new (...args: any[]) => any) | undefined;
+  if (typeof EventCtor === 'function' && value instanceof EventCtor) return true;
+
+  const WindowCtor = g.Window as (new (...args: any[]) => any) | undefined;
+  if (typeof WindowCtor === 'function' && value instanceof WindowCtor) return true;
+
+  return false;
+}
+
+function fallbackClone<T>(value: T): T {
+  const seen = new WeakMap<object, any>();
+
+  const walk = (v: any): any => {
+    if (v === null || v === undefined) return v;
+
+    const t = typeof v;
+    if (t === 'string' || t === 'number' || t === 'boolean') return v;
+    if (t === 'bigint') return Number(v);
+    if (t === 'symbol' || t === 'function') return undefined;
+
+    if (isDomLike(v)) return undefined;
+
+    if (v instanceof Date) return new Date(v.getTime());
+
+    if (t !== 'object') return undefined;
+
+    if (seen.has(v)) return seen.get(v);
+
+    if (Array.isArray(v)) {
+      const out: any[] = [];
+      seen.set(v, out);
+      for (const item of v) {
+        const next = walk(item);
+        if (next !== undefined) out.push(next);
+      }
+      return out;
+    }
+
+    if (v instanceof Map) {
+      const out = new Map();
+      seen.set(v, out);
+      for (const [k, val] of v.entries()) {
+        const nk = walk(k);
+        const nv = walk(val);
+        if (nk !== undefined && nv !== undefined) out.set(nk, nv);
+      }
+      return out;
+    }
+
+    if (v instanceof Set) {
+      const out = new Set();
+      seen.set(v, out);
+      for (const item of v.values()) {
+        const next = walk(item);
+        if (next !== undefined) out.add(next);
+      }
+      return out;
+    }
+
+    const out: Record<string, any> = {};
+    seen.set(v, out);
+
+    for (const [k, val] of Object.entries(v)) {
+      const next = walk(val);
+      if (next !== undefined) out[k] = next;
+    }
+
+    return out;
+  };
+
+  return walk(value) as T;
+}
+
 function clone<T>(value: T): T {
-  if (typeof (globalThis as any).structuredClone === 'function') {
-    return (globalThis as any).structuredClone(value);
+  const sc = (globalThis as any).structuredClone as ((input: any) => any) | undefined;
+  if (typeof sc === 'function') {
+    try {
+      return sc(value);
+    } catch {
+      return fallbackClone(value);
+    }
   }
-  return JSON.parse(JSON.stringify(value)) as T;
+
+  return fallbackClone(value);
 }
 
 export class MediaResponseSystem {

--- a/tests/mediaSystem.test.ts
+++ b/tests/mediaSystem.test.ts
@@ -494,4 +494,42 @@ describe('media system', () => {
     expect(items[0].headline).not.toMatch(/\{[A-Za-z]+\}/);
     expect(items[0].content).not.toMatch(/\{[A-Za-z]+\}/);
   });
+
+  it('can hydrate when persisted media state includes non-cloneable values (e.g. functions)', () => {
+    const playerStudio = { id: 'player-studio', name: 'Player Studio', reputation: 50, budget: 1000000, founded: 2025, specialties: ['drama'] };
+    const playerProject = makeMinimalProject({
+      id: 'player-project-1',
+      title: 'Player Premiere',
+      studioName: playerStudio.name,
+      releaseWeek: 1,
+      releaseYear: 2025,
+      cast: [{ talentId: 'talent-1' }]
+    });
+
+    MediaEngine.queueMediaEvent({
+      type: 'release',
+      triggerType: 'automatic',
+      priority: 'low',
+      entities: {
+        studios: [playerStudio.id],
+        projects: [playerProject.id],
+        talent: ['talent-1']
+      },
+      eventData: { project: playerProject, nonCloneable: () => 'nope' },
+      week: 1,
+      year: 2025
+    } as any);
+
+    const persisted = { engine: MediaEngine.snapshot(), response: { campaigns: [], reactions: [] } } as any;
+
+    MediaEngine.cleanup();
+
+    expect(() => {
+      MediaEngine.hydrate(persisted);
+    }).not.toThrow();
+
+    const hydrated = MediaEngine.snapshot();
+    expect(hydrated.eventQueue.length).toBe(1);
+    expect(hydrated.eventQueue[0].eventData.nonCloneable).toBeUndefined();
+  });
 });


### PR DESCRIPTION
The changes introduce a safer cloning strategy for media state hydration to avoid DataCloneError when persisting or hydrating complex/non-serializable values.

What changed:
- Added DOM-like detection and a fallback deep clone in mediaEngine.ts and mediaResponseSystem.ts:
  - isDomLike(value) detects DOM-like objects to skip cloning them.
  - fallbackClone(value) recursively clones common data structures (arrays, maps, sets, plain objects, and Date) while dropping non-cloneable values (functions, symbols).
  - clone(value) now prefers globalThis.structuredClone when available, but gracefully falls back to fallbackClone on error.

Why:
- Previously, hydration could throw a DataCloneError when persisted state contained non-cloneable values (e.g., functions), breaking the app flow.
- The new implementation ensures hydration can proceed safely by dropping non-cloneable fields instead of throwing.

Tests:
- Updated test coverage to validate hydration works when persisted media state includes non-cloneable values (e.g., a function in eventData).
- The test asserts that such non-cloneable fields are undefined after hydration, and that the event queue hydrates correctly.

Outcome:
- Hydration no longer throws on non-cloneable data, and the engine gracefully handles complex or DOM-like values by skipping or dropping non-serializable parts. This aligns with the observed runtime issue and stabilizes the hydration flow.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/bkdr1rxx6sns
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/140
Author: Evan Lewis