### PR TITLE
Remove DEV-only TV System Tests item from Studio menu

### DIFF
--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -2880,12 +2880,6 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
                    <BarChartIcon className="mr-2" size={16} />
                    Television & Streaming
                  </DropdownMenuItem>
-                 {import.meta.env.DEV && (
-                   <DropdownMenuItem onClick={() => handlePhaseChange('tv-tests')}>
-                     <BarChartIcon className="mr-2" size={16} />
-                     TV System Tests
-                   </DropdownMenuItem>
-                 )}
                 <DropdownMenuItem onClick={() => handlePhaseChange('awards')}>
                   <ReputationIcon className="mr-2" size={16} />
                   Awards & Recognition


### PR DESCRIPTION
Removes the TV System Tests option from the StudioMagnateGame dropdown. Previously this item was rendered only in development (wrapped in import.meta.env.DEV); it has been deleted so the TV System Tests are no longer visible under Studio in any environment. Other Studio items (Television & Streaming, Awards & Recognition) remain unchanged. To verify, open the Studio menu and confirm the TV System Tests entry is no longer present; ensure other items render as before.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/2uglcu5cbp01
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/141
Author: Evan Lewis