### PR TITLE
Enable React Router v7 future flags and remove structuredClone usage in media hydration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,10 @@ const App = () => (
       <Toaster />
       <Sonner />
       <ErrorBoundary>
-        <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <BrowserRouter
+          basename={import.meta.env.BASE_URL}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
           <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
             <Routes>
               <Route path="/" element={<Index />} />

--- a/src/game/media/mediaEngine.ts
+++ b/src/game/media/mediaEngine.ts
@@ -87,15 +87,6 @@ function fallbackClone<T>(value: T): T {
 }
 
 function clone<T>(value: T): T {
-  const sc = (globalThis as any).structuredClone as ((input: any) => any) | undefined;
-  if (typeof sc === 'function') {
-    try {
-      return sc(value);
-    } catch {
-      return fallbackClone(value);
-    }
-  }
-
   return fallbackClone(value);
 }
 

--- a/src/game/media/mediaResponseSystem.ts
+++ b/src/game/media/mediaResponseSystem.ts
@@ -84,15 +84,6 @@ function fallbackClone<T>(value: T): T {
 }
 
 function clone<T>(value: T): T {
-  const sc = (globalThis as any).structuredClone as ((input: any) => any) | undefined;
-  if (typeof sc === 'function') {
-    try {
-      return sc(value);
-    } catch {
-      return fallbackClone(value);
-    }
-  }
-
   return fallbackClone(value);
 }
 

--- a/tests/mediaSystem.test.ts
+++ b/tests/mediaSystem.test.ts
@@ -524,9 +524,23 @@ describe('media system', () => {
 
     MediaEngine.cleanup();
 
-    expect(() => {
-      MediaEngine.hydrate(persisted);
-    }).not.toThrow();
+    const originalStructuredClone = (globalThis as any).structuredClone;
+    let structuredCloneCalls = 0;
+
+    (globalThis as any).structuredClone = () => {
+      structuredCloneCalls += 1;
+      throw new Error('structuredClone should not be used during MediaEngine hydration');
+    };
+
+    try {
+      expect(() => {
+        MediaEngine.hydrate(persisted);
+      }).not.toThrow();
+    } finally {
+      (globalThis as any).structuredClone = originalStructuredClone;
+    }
+
+    expect(structuredCloneCalls).toBe(0);
 
     const hydrated = MediaEngine.snapshot();
     expect(hydrated.eventQueue.length).toBe(1);


### PR DESCRIPTION
What I changed:

- React Router: Enabled early adoption of v7 features by passing future flags to BrowserRouter. The app now opt-in to v7_startTransition and v7_relativeSplatPath to align with upcoming changes and suppress related warnings.

- Media hydration: Removed usage of structuredClone in clone() paths for mediaEngine and mediaResponseSystem. Hydration now relies on the existing fallbackClone path, avoiding potential structuredClone errors during hydration.

- Tests: Updated media system tests to verify that structuredClone is not invoked during MediaEngine.hydrate. The test temporarily overrides globalThis.structuredClone to ensure it is not called, then restores the original implementation.

Rationale:
- The Router change prepares the app for v7 behavior while keeping current behavior functional.
- Removing structuredClone usage avoids clone-related errors in hydration workflows and simplifies cloning logic, improving stability across environments where structuredClone may not be reliable.


https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/zxniq2y3nlth
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/142
Author: Evan Lewis