### PR TITLE
Remove unnecessary butler whoami invocation from itch-release workflow

### DIFF
--- a/.github/workflows/itch-release.yml
+++ b/.github/workflows/itch-release.yml
@@ -338,9 +338,6 @@ jobs:
             echo "butler version:";
             butler -V;
             echo;
-            echo "butler whoami:";
-            butler whoami;
-            echo;
             echo "Uploading ${{ steps.artifact.outputs.path }} -> ${TARGET_BASE}:${{ matrix.channel }} (userversion: $VERSION)";
             butler push "${{ steps.artifact.outputs.path }}" "${TARGET_BASE}:${{ matrix.channel }}" --userversion "$VERSION";
           } 2>&1 | tee "$BUTLER_LOG_FILE"


### PR DESCRIPTION
The itch-release GitHub Actions workflow previously attempted to run `butler whoami`, which is not a valid command for the version in use and could cause the release job to fail. This change removes that block (echo and the `butler whoami` call) while keeping the rest of the release steps intact (version display and artifact push). This makes the release workflow more robust across butler versions.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/4l9jgh03rybl
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/144
Author: Evan Lewis