### PR TITLE
Switch itch-release workflow to jdno/setup-butler@v1 for Butler v15 compatibility

### DIFF
--- a/.github/workflows/itch-release.yml
+++ b/.github/workflows/itch-release.yml
@@ -298,7 +298,9 @@ jobs:
           if-no-files-found: error
 
       - name: Setup butler
-        uses: remarkablegames/setup-butler@v2
+        # remarkablegames/setup-butler@v2 runs `butler whoami`, which was removed in butler v15.
+        # jdno/setup-butler only installs butler and doesn't rely on deprecated commands.
+        uses: jdno/setup-butler@v1
 
       - name: Upload to itch.io
         shell: bash


### PR DESCRIPTION
Replaces the Setup butler action in .github/workflows/itch-release.yml from remarkablegames/setup-butler@v2 to jdno/setup-butler@v1. Butler v15 removed commands like 'whoami' that the previous action relied on, causing the CI step to fail. The new jdno/setup-butler@v1 simply installs Butler without invoking deprecated commands, allowing the workflow to proceed to the upload step. No other workflow logic changes; this fixes the CI error and keeps itch.io uploads functional.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/alarxzm2baw1
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/145
Author: Evan Lewis