### PR TITLE
Add macOS ARM64 Butler bootstrap in GitHub Actions and separate platform install path

### DIFF
--- a/.github/workflows/itch-release.yml
+++ b/.github/workflows/itch-release.yml
@@ -297,10 +297,35 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
 
-      - name: Setup butler
+      - name: Setup butler (Linux/Windows)
+        if: matrix.platform != 'macos-latest'
         # remarkablegames/setup-butler@v2 runs `butler whoami`, which was removed in butler v15.
-        # jdno/setup-butler only installs butler and doesn't rely on deprecated commands.
+        # jdno/setup-butler only supports x64 + i386 (not macOS arm64).
         uses: jdno/setup-butler@v1
+
+      - name: Setup butler (macOS arm64)
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BUTLER_PLATFORM="darwin"
+          BUTLER_ARCH="arm64"
+
+          VERSION="$(curl -fsSL "https://broth.itch.zone/butler/${BUTLER_PLATFORM}-${BUTLER_ARCH}/LATEST")"
+          echo "Installing butler ${VERSION} (${BUTLER_PLATFORM}-${BUTLER_ARCH})"
+
+          OUT_DIR="${RUNNER_TEMP}/butler"
+          rm -rf "$OUT_DIR"
+          mkdir -p "$OUT_DIR"
+
+          curl -fsSL -o "$OUT_DIR/butler.zip" "https://broth.itch.zone/butler/${BUTLER_PLATFORM}-${BUTLER_ARCH}/${VERSION}/archive/default"
+          unzip -q "$OUT_DIR/butler.zip" -d "$OUT_DIR"
+          chmod +x "$OUT_DIR/butler"
+
+          echo "$OUT_DIR" >> "$GITHUB_PATH"
+
+          butler -V
 
       - name: Upload to itch.io
         shell: bash


### PR DESCRIPTION
This update adds explicit Butler installation for macOS ARM64 in the GitHub Actions workflow and splits the platform-specific setup paths.

What changed:
- Split setup steps:
  - Linux/Windows: continue using jdno/setup-butler@v1 (conditioned on non-macos-latest)
  - macOS arm64: new dedicated bootstrap that downloads and installs the Butler binary for darwin-arm64 from broth, makes it executable, and adds it to PATH
- The macOS arm64 step downloads the latest version, unpacks, and ensures and runs butler -V to verify installation
- PATH is updated via the GITHUB_PATH mechanism so subsequent steps can call butler

Rationale:
- Butler v15 deprecated or altered commands like whoami, and the previous setup path could fail on macOS arm64 runners. This change provides a robust, platform-specific installation that works with the latest Butler builds across all runners.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/d0g29h6g36cv
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/146
Author: Evan Lewis