### PR TITLE
CI: Update actions to latest v5/v6 and add Rosetta-based macOS arm64 support for butler

### DIFF
--- a/.github/workflows/itch-release.yml
+++ b/.github/workflows/itch-release.yml
@@ -253,7 +253,25 @@ jobs:
               cp -R src-tauri/target/release/resources portable/
             fi
 
-            tar -a -c -f studio-magnate-windows-portable.zip -C portable .
+            rm -f studio-magnate-windows-portable.zip
+
+            python - <<'PY'
+            import os
+            import zipfile
+
+            out_path = "studio-magnate-windows-portable.zip"
+            root_dir = "portable"
+
+            with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+              for folder, _, files in os.walk(root_dir):
+                for name in files:
+                  path = os.path.join(folder, name)
+                  arcname = os.path.relpath(path, root_dir)
+                  zf.write(path, arcname)
+            PY
+
+            python -c 'import sys, zipfile; z=zipfile.ZipFile("studio-magnate-windows-portable.zip"); bad=z.testzip(); sys.exit(0 if bad is None else 1)'
+
             echo "path=studio-magnate-windows-portable.zip" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
What this PR does
- Upgrades GitHub Actions to newer major versions to align with Node.js 24 readiness: actions/checkout@v5, actions/setup-node@v6, and actions/upload-artifact@v6.
- Consolidates butler setup into a single Setup butler step that dynamically determines the platform and architecture, rather than separate macOS arm64 handling.
- Adds a Rosetta-based workaround for macOS arm64 runners: installs Rosetta if needed and wraps the butler binary so it runs under x86_64 when on macOS arm64.
- Improves extraction of the downloaded butler package by using Python’s zipfile module instead of unzip, then sets executable permissions across platforms.
- Ensures Windows/macOS/Linux paths are handled consistently and creates a wrapper script on Windows when needed to invoke the correct binary.
- Updates artifact upload steps to use the latest actions versions.

Why this solves the issue
- The previous workflow used Node.js 20-era actions that are deprecated and could fail on newer runners. Upgrading to v5/v6 helps ensure Node.js 24 compatibility and reduces the risk of runner failures.
- Mac runners on arm64 had compatibility issues with butler distributions. The Rosetta-based approach enables running the x86_64 butler on arm64 Macs, resolving the macOS arm64 errors while preserving proper functionality.


https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/4va5is5r430q
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/147
Author: Evan Lewis