### PR TITLE
Fix TypeScript typing in platform originals pipeline and initialize aiStudioProjects in store for stable save/load

### DIFF
--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -271,7 +271,12 @@ export const useGameStore: import('zustand').UseBoundStore<import('zustand').Sto
     initGame: (state, seed) => {
       const gameSeed = seed ?? generateGameSeed();
       set((s) => {
-        const next = { ...state, universeSeed: state.universeSeed ?? gameSeed, rngState: state.rngState ?? gameSeed };
+        const next = {
+          ...state,
+          universeSeed: state.universeSeed ?? gameSeed,
+          rngState: state.rngState ?? gameSeed,
+          aiStudioProjects: state.aiStudioProjects ?? [],
+        };
         s.game = normalizeStudioGovernanceState(normalizePublicDomainState(normalizeFranchisesState(next) as any) as any);
         s.seed = gameSeed;
         s.rng = createRng(gameSeed);
@@ -296,6 +301,7 @@ export const useGameStore: import('zustand').UseBoundStore<import('zustand').Sto
           ...state,
           universeSeed: typeof state.universeSeed === 'number' ? state.universeSeed : derivedUniverseSeed,
           rngState: typeof state.rngState === 'number' ? state.rngState : derivedRngState,
+          aiStudioProjects: state.aiStudioProjects ?? [],
         };
         s.game = normalizeStudioGovernanceState(normalizePublicDomainState(normalizeFranchisesState(next) as any) as any);
         s.seed = gameSeed;
@@ -349,6 +355,7 @@ export const useGameStore: import('zustand').UseBoundStore<import('zustand').Sto
           ...(result.nextState as any),
           universeSeed: (s.game as any)?.universeSeed,
           rngState: rng.state,
+          aiStudioProjects: (result.nextState as any).aiStudioProjects ?? (s.game as any)?.aiStudioProjects ?? [],
         };
         s.game = normalizeStudioGovernanceState(normalizePublicDomainState(normalizeFranchisesState(next) as any) as any);
         // Persist the PRNG state ("seed" here is treated as current RNG state).

--- a/src/game/systems/platformOriginalsPipelineSystem.ts
+++ b/src/game/systems/platformOriginalsPipelineSystem.ts
@@ -114,7 +114,7 @@ export const PlatformOriginalsPipelineSystem: TickSystem = {
 
         const out: Project = {
           ...p,
-          currentPhase: phase,
+          currentPhase: phase as Project['currentPhase'],
           status: phase,
           phaseDuration: nextRemaining,
           ...(seasonsOut ? { seasons: seasonsOut } : {}),
@@ -142,7 +142,7 @@ export const PlatformOriginalsPipelineSystem: TickSystem = {
 
         const out: Project = {
           ...p,
-          currentPhase: phaseAfter,
+          currentPhase: phaseAfter as Project['currentPhase'],
           status: phaseAfter,
           phaseDuration: defaultPhaseWeeks(phaseAfter),
           ...(seasonsOut ? { seasons: seasonsOut } : {}),
@@ -185,7 +185,7 @@ export const PlatformOriginalsPipelineSystem: TickSystem = {
       const out: Project = {
         ...p,
         status: 'released',
-        currentPhase: 'distribution',
+        currentPhase: 'distribution' as Project['currentPhase'],
         phaseDuration: 0,
         releaseWeek: ctx.week,
         releaseYear: ctx.year,


### PR DESCRIPTION
This PR fixes two related issues:

- Type safety in PlatformOriginalsPipelineSystem: TS2345/TS2322 errors occurred due to currentPhase being treated as a string in some assignments. The code now casts currentPhase to Project['currentPhase'] where we construct updated project objects (three locations). This aligns with the Project type and resolves the typing errors.

- Persisted state stability for save/load roundtrips: The game store now ensures aiStudioProjects is always initialized and propagated across all state transitions. Specifically, we:
  - Initialize aiStudioProjects to [] in the init path when undefined.
  - Persist aiStudioProjects in the next state and in the rehydration/patch logic so the saved game state preserves the full project structure (including allReleases) and roundtrips correctly.

These changes prevent TypeScript compilation errors and fix save/load roundtrip inconsistencies where allReleases could be missing from the serialized state.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/dchnnmlix0ol
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/151
Author: Evan Lewis