### PR TITLE
Enable ChromeOS-friendly dev server by honoring TAURI_DEV_HOST and adjusting Vite config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "version": "../package.json",
   "identifier": "com.studiomagnate.studiomagnate",
   "build": {
-    "beforeDevCommand": "npm run dev -- --host 127.0.0.1 --port 1420 --strictPort",
+    "beforeDevCommand": "npm run dev -- --port 1420 --strictPort",
     "devUrl": "http://127.0.0.1:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { componentTagger } from "lovable-tagger";
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
+const tauriDevHost = process.env.TAURI_DEV_HOST;
 
 function normalizeBase(base: string): string {
   const trimmed = base.trim();
@@ -43,8 +44,15 @@ export default defineConfig(({ mode }) => {
   return {
     base,
     server: {
-      host: "127.0.0.1",
+      host: tauriDevHost || "127.0.0.1",
       port: 8080,
+      hmr: tauriDevHost
+        ? {
+          protocol: "ws",
+          host: tauriDevHost,
+          port: 1421,
+        }
+        : undefined,
     },
     plugins: [
       react(),


### PR DESCRIPTION
Adds support for building/running the Tauri app on ChromeOS by introducing a TAURI_DEV_HOST environment variable and adapting the Vite dev server accordingly. The beforeDevCommand no longer forces a host, and the Vite server binds to TAURI_DEV_HOST when provided (defaulting to 127.0.0.1). When a host is specified, HMR uses WebSocket on that host/port 1421. This enables accessing the dev server from ChromeOS devices on the same network. tauri.conf.json is updated to drop the explicit host in the dev command while keeping the devUrl pointing to localhost:1420. No changes to frontend distribution. If running on a non-default host, set TAURI_DEV_HOST to the desired address.

https://cosine.sh/w45mw06ms2s7/studio-dynasty-builder/task/xolbq7u3tl6n
https://cosine.sh/gh/evanlew15601-hash/studio-dynasty-builder/pull/153
Author: Evan Lewis