### PR TITLE
Add franchise continuity, character/talent libraries, and dashboard; update normalization and import logic

### DIFF
--- a/src/components/game/EnhancedFranchiseSystem.tsx
+++ b/src/components/game/EnhancedFranchiseSystem.tsx
@@ -145,7 +145,24 @@ export const EnhancedFranchiseSystem: React.FC<EnhancedFranchiseSystemProps> = (
       status: 'active',
       franchiseTags: [`${project.script.genre}`, 'original'],
       culturalWeight: Math.min(90, 40 + (project.metrics?.criticsScore || 0) / 2),
-      cost: 0 // No ongoing costs for owned franchise
+      cost: 0, // No ongoing costs for owned franchise
+      characterLibrary: [],
+      talentLibrary: [],
+      continuity: {
+        timelineEvents: [],
+        characterAppearances: {},
+        deaths: {},
+        relationships: [],
+        locations: [],
+        plotThreads: [],
+        warnings: [],
+      },
+      franchiseBible: {
+        worldbuilding: [`Originated with ${project.title}.`],
+        relationshipMap: [],
+        sequelHooks: ['Protect original cast continuity before greenlighting a sequel.'],
+        plannedArc: 'saga',
+      },
     };
 
     // Update the original project to be part of the franchise
@@ -198,7 +215,24 @@ export const EnhancedFranchiseSystem: React.FC<EnhancedFranchiseSystemProps> = (
       status: 'active',
       franchiseTags: ['original', 'studio-created'],
       culturalWeight: newFranchise.culturalWeight,
-      cost: 0
+      cost: 0,
+      characterLibrary: [],
+      talentLibrary: [],
+      continuity: {
+        timelineEvents: [],
+        characterAppearances: {},
+        deaths: {},
+        relationships: [],
+        locations: [],
+        plotThreads: [],
+        warnings: [],
+      },
+      franchiseBible: {
+        worldbuilding: newFranchise.description ? [newFranchise.description] : [],
+        relationshipMap: [],
+        sequelHooks: ['Build the character library before launching the first sequel.'],
+        plannedArc: 'trilogy',
+      },
     };
 
     upsertFranchise(franchise);

--- a/src/components/game/FranchiseManagementSystem.tsx
+++ b/src/components/game/FranchiseManagementSystem.tsx
@@ -69,7 +69,24 @@ export const FranchiseManagementSystem: React.FC<FranchiseManagementSystemProps>
       status: 'active',
       franchiseTags: [],
       culturalWeight: newFranchise.culturalWeight,
-      cost: 0 // Original franchise costs nothing to use once created
+      cost: 0, // Original franchise costs nothing to use once created
+      characterLibrary: [],
+      talentLibrary: [],
+      continuity: {
+        timelineEvents: [],
+        characterAppearances: {},
+        deaths: {},
+        relationships: [],
+        locations: [],
+        plotThreads: [],
+        warnings: [],
+      },
+      franchiseBible: {
+        worldbuilding: newFranchise.description ? [newFranchise.description] : [],
+        relationshipMap: [],
+        sequelHooks: ['Introduce franchise-defining characters before greenlighting a continuation.'],
+        plannedArc: 'trilogy',
+      },
     };
 
     onCreateFranchise(franchise);

--- a/src/components/game/OwnedFranchiseManager.tsx
+++ b/src/components/game/OwnedFranchiseManager.tsx
@@ -10,7 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Crown, Edit3, TrendingUp, Users, DollarSign, Star, Calendar } from 'lucide-react';
+import { AlertTriangle, BookOpen, Calendar, Crown, Edit3, GitBranch, Skull, Star, TrendingUp, Users, UserX } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { FinancialEngine } from './FinancialEngine';
 
@@ -36,6 +36,7 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
     description: '',
     status: 'active' as 'active' | 'dormant' | 'rebooted' | 'retired'
   });
+  const [selectedDashboardId, setSelectedDashboardId] = useState<string | null>(null);
 
   if (!gameState) {
     return <div className="p-6 text-sm text-muted-foreground">Loading franchises...</div>;
@@ -116,6 +117,65 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
     });
 
     setEditingFranchise(null);
+  };
+
+  const updateCharacterStatus = (franchise: Franchise, characterId: string, status: 'active' | 'retired' | 'deceased' | 'unavailable') => {
+    const currentContinuity = franchise.continuity || {
+      timelineEvents: [],
+      characterAppearances: {},
+      deaths: {},
+      relationships: [],
+      locations: [],
+      plotThreads: [],
+      warnings: [],
+    };
+
+    updateFranchise(franchise.id, {
+      characterLibrary: (franchise.characterLibrary || []).map((character) =>
+        character.characterId === characterId ? { ...character, status } : character
+      ),
+      continuity: {
+        ...currentContinuity,
+        deaths: status === 'deceased'
+          ? {
+              ...currentContinuity.deaths,
+              [characterId]: { description: 'Marked deceased in franchise canon.' },
+            }
+          : currentContinuity.deaths,
+        warnings: Array.from(new Set([
+          ...(currentContinuity.warnings || []),
+          status === 'deceased' ? `${franchise.characterLibrary?.find((c) => c.characterId === characterId)?.name || characterId} is deceased in canon.` : '',
+          status === 'unavailable' ? `${franchise.characterLibrary?.find((c) => c.characterId === characterId)?.name || characterId} is unavailable for new entries.` : '',
+        ].filter(Boolean))),
+      },
+    });
+  };
+
+  const promoteCharacter = (franchise: Franchise, characterId: string) => {
+    updateFranchise(franchise.id, {
+      characterLibrary: (franchise.characterLibrary || []).map((character) =>
+        character.characterId === characterId
+          ? { ...character, narrativeImportance: 'lead', recurrencePotential: Math.max(character.recurrencePotential, 90) }
+          : character
+      ),
+    });
+  };
+
+  const getFranchiseIntelligence = (franchise: Franchise, metrics: ReturnType<typeof getFranchiseMetrics>): string[] => {
+    const recommendations: string[] = [];
+    const topCharacter = [...(franchise.characterLibrary || [])].sort((a, b) => (b.popularity || b.recurrencePotential) - (a.popularity || a.recurrencePotential))[0];
+    const returningDirector = franchise.talentLibrary?.find((t) => t.role === 'director' && t.continuityPreference === 'return');
+    const unavailableTalent = franchise.talentLibrary?.find((t) => t.status === 'busy' || t.status === 'contract-conflict');
+    const activeThreads = franchise.continuity?.plotThreads?.filter((thread) => thread.status === 'active') || [];
+
+    if (topCharacter) recommendations.push(`Audience interest strongly favors ${topCharacter.name} returning.`);
+    if (returningDirector) recommendations.push('Previous director continuity is available and should be considered before replacement.');
+    if (unavailableTalent) recommendations.push(`${unavailableTalent.name || unavailableTalent.talentId} has a ${unavailableTalent.status === 'busy' ? 'scheduling' : 'contract'} conflict; plan buyout, recasting, or replacement explicitly.`);
+    if (metrics.projectCount >= 2 && metrics.avgCriticsScore >= 80) recommendations.push('Recent entries are critically strong; preserve the core creative team.');
+    if (activeThreads.length > 0) recommendations.push(`${activeThreads.length} active story arc${activeThreads.length === 1 ? '' : 's'} can anchor the next installment.`);
+    if (metrics.projectCount > 0 && metrics.profitability < 0) recommendations.push('Box office trend is weak; consider a lower-budget spin-off or TV adaptation.');
+
+    return recommendations.length > 0 ? recommendations : ['No major continuity risks detected; the franchise is ready for a new entry.'];
   };
 
   if (ownedFranchises.length === 0) {
@@ -232,6 +292,134 @@ export const OwnedFranchiseManager: React.FC<OwnedFranchiseManagerProps> = ({
                     <span>Avg Critics: {metrics.avgCriticsScore.toFixed(0)}/100</span>
                   </div>
                 </div>
+
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setSelectedDashboardId(selectedDashboardId === franchise.id ? null : franchise.id)}
+                >
+                  <BookOpen className="h-4 w-4 mr-2" />
+                  {selectedDashboardId === franchise.id ? 'Hide' : 'Open'} Franchise Dashboard
+                </Button>
+
+                {selectedDashboardId === franchise.id && (
+                  <div className="space-y-4 rounded-lg border bg-muted/20 p-4">
+                    <div>
+                      <h4 className="font-medium mb-2 flex items-center gap-2">
+                        <AlertTriangle className="h-4 w-4" />
+                        Franchise Intelligence
+                      </h4>
+                      <div className="grid gap-2">
+                        {getFranchiseIntelligence(franchise, metrics).map((recommendation) => (
+                          <div key={recommendation} className="rounded border bg-background p-2 text-sm">
+                            {recommendation}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="grid gap-4 lg:grid-cols-2">
+                      <div>
+                        <h4 className="font-medium mb-2 flex items-center gap-2">
+                          <Users className="h-4 w-4" />
+                          Character Library ({franchise.characterLibrary?.length || 0})
+                        </h4>
+                        <div className="grid gap-2">
+                          {(franchise.characterLibrary || []).map((character) => (
+                            <div key={character.characterId} className="rounded border bg-background p-3">
+                              <div className="flex items-start justify-between gap-2">
+                                <div>
+                                  <div className="font-medium">{character.name}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {character.gender}, {character.ageRange[0]}-{character.ageRange[1]} • {character.narrativeImportance} • recurrence {character.recurrencePotential}/100
+                                  </div>
+                                  <p className="text-sm text-muted-foreground mt-1">{character.description}</p>
+                                  <div className="text-xs text-muted-foreground mt-1">
+                                    Appearances: {character.appearances.length || 0} • Popularity: {character.popularity || 0}/100
+                                  </div>
+                                </div>
+                                <Badge variant={character.status === 'active' ? 'default' : 'secondary'}>{character.status}</Badge>
+                              </div>
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                <Button size="sm" variant="outline" onClick={() => promoteCharacter(franchise, character.characterId)}>
+                                  Promote
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => updateCharacterStatus(franchise, character.characterId, 'retired')}>
+                                  <UserX className="h-3 w-3 mr-1" />
+                                  Retire
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => updateCharacterStatus(franchise, character.characterId, 'deceased')}>
+                                  <Skull className="h-3 w-3 mr-1" />
+                                  Deceased
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => updateCharacterStatus(franchise, character.characterId, 'unavailable')}>
+                                  Unavailable
+                                </Button>
+                                {character.status !== 'active' && (
+                                  <Button size="sm" variant="outline" onClick={() => updateCharacterStatus(franchise, character.characterId, 'active')}>
+                                    Restore
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
+                          ))}
+                          {(franchise.characterLibrary || []).length === 0 && (
+                            <div className="rounded border bg-background p-3 text-sm text-muted-foreground">
+                              No library entries yet. Release or attach a franchise project to audit characters automatically.
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-4">
+                        <div>
+                          <h4 className="font-medium mb-2 flex items-center gap-2">
+                            <Star className="h-4 w-4" />
+                            Talent Library ({franchise.talentLibrary?.length || 0})
+                          </h4>
+                          <div className="grid gap-2">
+                            {(franchise.talentLibrary || []).map((talent) => (
+                              <div key={`${talent.talentId}-${talent.characterId || talent.role}`} className="rounded border bg-background p-2 text-sm">
+                                <div className="flex items-center justify-between">
+                                  <span>{talent.name || talent.talentId} • {talent.role}</span>
+                                  <Badge variant={talent.status === 'available' ? 'default' : 'secondary'}>{talent.status}</Badge>
+                                </div>
+                                {talent.warning && <div className="mt-1 text-xs text-amber-600">{talent.warning}</div>}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <h4 className="font-medium mb-2 flex items-center gap-2">
+                            <GitBranch className="h-4 w-4" />
+                            Canon & Continuity
+                          </h4>
+                          <div className="rounded border bg-background p-3 text-sm space-y-2">
+                            <div>Timeline events: {franchise.continuity?.timelineEvents?.length || 0}</div>
+                            <div>Active story arcs: {franchise.continuity?.plotThreads?.filter((thread) => thread.status === 'active').length || 0}</div>
+                            <div>Returning locations: {franchise.continuity?.locations?.length || 0}</div>
+                            {(franchise.continuity?.warnings || []).map((warning) => (
+                              <div key={warning} className="text-amber-600">{warning}</div>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <h4 className="font-medium mb-2 flex items-center gap-2">
+                            <BookOpen className="h-4 w-4" />
+                            Franchise Bible
+                          </h4>
+                          <div className="rounded border bg-background p-3 text-sm space-y-2">
+                            <div>Planned arc: {franchise.franchiseBible?.plannedArc || 'standalone'}</div>
+                            <div>Worldbuilding notes: {franchise.franchiseBible?.worldbuilding?.length || 0}</div>
+                            <div>Future hooks: {(franchise.franchiseBible?.sequelHooks || []).join(' • ') || 'None yet'}</div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
                 {/* Franchise Projects */}
                 {metrics.projects.length > 0 && (

--- a/src/components/game/SequelManagement.tsx
+++ b/src/components/game/SequelManagement.tsx
@@ -271,7 +271,24 @@ export const SequelManagement: React.FC<SequelManagementProps> = ({
           status: 'active',
           franchiseTags: ['sequel-ready', 'successful'],
           culturalWeight: Math.min(90, 50 + ((selectedProject.metrics?.criticsScore || 0) / 2)),
-          cost: 0
+          cost: 0,
+          characterLibrary: [],
+          talentLibrary: [],
+          continuity: {
+            timelineEvents: [],
+            characterAppearances: {},
+            deaths: {},
+            relationships: [],
+            locations: [],
+            plotThreads: [],
+            warnings: [],
+          },
+          franchiseBible: {
+            worldbuilding: [`Built from ${selectedProject.title}.`],
+            relationshipMap: [],
+            sequelHooks: ['Carry forward returning cast and unresolved story threads.'],
+            plannedArc: 'saga',
+          },
         };
         
         // Add franchise to game state and update original project if callback provided

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -28,6 +28,58 @@ export interface Franchise {
   criticalFatigue?: number; // 0-100, increases with poor sequels
   description?: string; // Bio/background for player familiarity
   cost: number; // Cost to license/use franchise based on cultural weight
+  /** Permanent cast bible for this IP. Characters should persist across sequels/spin-offs. */
+  characterLibrary?: FranchiseCharacterLibraryEntry[];
+  /** Talent continuity memory for returning cast/crew and replacement warnings. */
+  talentLibrary?: FranchiseTalentLibraryEntry[];
+  /** Canon/continuity database for cross-entry validation and dashboard display. */
+  continuity?: FranchiseContinuityDatabase;
+  /** Long-term franchise planning data for original IPs and acquired properties. */
+  franchiseBible?: FranchiseBible;
+}
+
+export interface FranchiseCharacterLibraryEntry {
+  characterId: string;
+  name: string;
+  ageRange: [number, number];
+  gender: Gender;
+  description: string;
+  narrativeImportance: 'lead' | 'supporting' | 'recurring' | 'minor' | 'cameo';
+  recurrencePotential: number; // 0-100
+  status: 'active' | 'retired' | 'deceased' | 'unavailable';
+  traits?: string[];
+  relationships?: { characterId: string; relationship: string }[];
+  firstAppearanceProjectId?: string;
+  appearances: string[];
+  popularity?: number;
+}
+
+export interface FranchiseTalentLibraryEntry {
+  talentId: string;
+  name?: string;
+  role: 'actor' | 'director' | 'writer' | 'producer' | 'crew';
+  characterId?: string;
+  projectIds: string[];
+  continuityPreference: 'return' | 'recast-ok' | 'replace-ok';
+  status: 'available' | 'busy' | 'contract-conflict' | 'retired' | 'unknown';
+  warning?: string;
+}
+
+export interface FranchiseContinuityDatabase {
+  timelineEvents: Array<{ id: string; projectId?: string; date?: string; description: string; type: 'appearance' | 'death' | 'relationship' | 'location' | 'plot' | 'retcon' }>;
+  characterAppearances: Record<string, string[]>;
+  deaths: Record<string, { projectId?: string; description: string }>;
+  relationships: Array<{ characterId: string; relatedCharacterId: string; relationship: string; projectId?: string }>;
+  locations: Array<{ id: string; name: string; appearances: string[] }>;
+  plotThreads: Array<{ id: string; description: string; status: 'active' | 'resolved' | 'retconned'; appearances: string[] }>;
+  warnings?: string[];
+}
+
+export interface FranchiseBible {
+  worldbuilding: string[];
+  relationshipMap: Array<{ fromCharacterId: string; toCharacterId: string; relationship: string }>;
+  sequelHooks: string[];
+  plannedArc?: 'standalone' | 'trilogy' | 'saga' | 'tv-adaptation';
 }
 
 // Public Domain System Types

--- a/src/utils/franchiseContinuity.ts
+++ b/src/utils/franchiseContinuity.ts
@@ -1,0 +1,98 @@
+import type { Franchise, FranchiseCharacterLibraryEntry, FranchiseTalentLibraryEntry, GameState, Project, ScriptCharacter } from '@/types/game';
+import { stablePick } from '@/utils/stablePick';
+import { isDirectorRole } from '@/utils/scriptRoles';
+
+const GENERIC_MAJOR_ROLE_NAMES = new Set([
+  'hero', 'lead', 'lead character', 'main character', 'main protagonist', 'protagonist',
+  'supporting character', 'supporting character #1', 'supporting character #2', 'friend',
+  'best friend', 'sidekick', 'villain', 'main villain', 'antagonist', 'love interest',
+  'mentor', 'director',
+]);
+
+export function isGenericMajorRoleName(character: Pick<ScriptCharacter, 'name' | 'importance' | 'requiredType'>): boolean {
+  if (character.requiredType === 'director' || character.importance === 'crew' || character.importance === 'minor') return false;
+  const name = (character.name || '').trim().toLowerCase();
+  return GENERIC_MAJOR_ROLE_NAMES.has(name) || /^supporting character #?\d+$/i.test(name);
+}
+
+export function namedCharacterForRole(role: ScriptCharacter, seed: string): ScriptCharacter {
+  if (!isGenericMajorRoleName(role)) return role;
+
+  const first = stablePick(['Alex', 'Mara', 'Julian', 'Clara', 'Victor', 'Nora', 'Elias', 'Iris'], `${seed}|first|${role.id}`);
+  const last = stablePick(['Vale', 'Cross', 'Sterling', 'Monroe', 'Hawke', 'Reed', 'Voss', 'Arden'], `${seed}|last|${role.id}`);
+  return {
+    ...role,
+    name: `${first} ${last}`,
+    description: role.description || `${role.importance === 'lead' ? 'Central' : 'Key recurring'} character in the franchise ensemble.`,
+  };
+}
+
+function characterIdFor(c: ScriptCharacter): string {
+  return c.franchiseCharacterId || c.roleTemplateId || c.id || c.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+export function buildCharacterLibrary(franchise: Franchise, projects: Project[] = []): FranchiseCharacterLibraryEntry[] {
+  const existing = new Map((franchise.characterLibrary || []).map((c) => [c.characterId, c]));
+
+  for (const project of projects) {
+    for (const raw of project.script?.characters || []) {
+      if (isDirectorRole(raw) || raw.importance === 'minor') continue;
+      const c = namedCharacterForRole(raw, `${franchise.id}|${project.id}`);
+      const id = characterIdFor(c);
+      const prev = existing.get(id);
+      const appearances = Array.from(new Set([...(prev?.appearances || []), project.id]));
+      existing.set(id, {
+        characterId: id,
+        name: c.name,
+        ageRange: c.ageRange || prev?.ageRange || [25, 45],
+        gender: c.requiredGender || prev?.gender || stablePick(['Male', 'Female'], `${id}|gender`),
+        description: c.description || prev?.description || 'Franchise character.',
+        narrativeImportance: c.importance === 'lead' ? 'lead' : c.importance === 'supporting' ? 'supporting' : 'recurring',
+        recurrencePotential: prev?.recurrencePotential ?? (c.importance === 'lead' ? 95 : 75),
+        status: prev?.status || 'active',
+        traits: c.traits || prev?.traits,
+        relationships: c.relationships || prev?.relationships,
+        firstAppearanceProjectId: prev?.firstAppearanceProjectId || project.id,
+        appearances,
+        popularity: prev?.popularity,
+      });
+    }
+  }
+
+  return Array.from(existing.values());
+}
+
+export function buildTalentLibrary(franchise: Franchise, projects: Project[] = [], gameState?: GameState): FranchiseTalentLibraryEntry[] {
+  const existing = new Map((franchise.talentLibrary || []).map((t) => [`${t.talentId}:${t.characterId || t.role}`, t]));
+  const talentById = new Map((gameState?.talent || []).map((t) => [t.id, t]));
+
+  for (const project of projects) {
+    for (const c of project.script?.characters || []) {
+      if (!c.assignedTalentId) continue;
+      const talent = talentById.get(c.assignedTalentId);
+      const role = isDirectorRole(c) ? 'director' : 'actor';
+      const key = `${c.assignedTalentId}:${role === 'actor' ? characterIdFor(c) : role}`;
+      const prev = existing.get(key);
+      const status = talent?.contractStatus === 'busy' ? 'busy' : talent?.contractStatus === 'retired' ? 'retired' : talent?.contractStatus === 'exclusive' ? 'contract-conflict' : 'available';
+      existing.set(key, {
+        talentId: c.assignedTalentId,
+        name: talent?.name,
+        role,
+        characterId: role === 'actor' ? characterIdFor(c) : undefined,
+        projectIds: Array.from(new Set([...(prev?.projectIds || []), project.id])),
+        continuityPreference: prev?.continuityPreference || 'return',
+        status,
+        warning: status === 'busy' ? 'Scheduling conflict: returning talent is busy.' : status === 'contract-conflict' ? 'Contract conflict: buyout or replacement required.' : prev?.warning,
+      });
+    }
+    for (const ct of project.contractedTalent || []) {
+      if (!['Writer', 'Producer', 'Director'].includes(ct.role)) continue;
+      const role = ct.role === 'Writer' ? 'writer' : ct.role === 'Producer' ? 'producer' : 'director';
+      const key = `${ct.talentId}:${role}`;
+      const prev = existing.get(key);
+      existing.set(key, { talentId: ct.talentId, role, projectIds: Array.from(new Set([...(prev?.projectIds || []), project.id])), continuityPreference: 'return', status: 'unknown' });
+    }
+  }
+
+  return Array.from(existing.values());
+}

--- a/src/utils/franchiseNormalization.ts
+++ b/src/utils/franchiseNormalization.ts
@@ -1,4 +1,5 @@
 import type { Franchise, GameState, Project, Script } from '@/types/game';
+import { buildCharacterLibrary, buildTalentLibrary, namedCharacterForRole } from '@/utils/franchiseContinuity';
 
 function uniqStrings(values: unknown): string[] {
   if (!Array.isArray(values)) return [];
@@ -220,6 +221,31 @@ export function normalizeFranchisesState(state: GameState): GameState {
 
   if (!projectsTouched) nextProjects = inputProjects;
 
+  let characterAuditTouched = false;
+  nextProjects = nextProjects.map((p) => {
+    const fid = (p as any)?.script?.franchiseId || (p as any)?.franchiseId;
+    const chars = (p as any)?.script?.characters;
+    if (!fid || !Array.isArray(chars) || chars.length === 0) return p;
+
+    let changed = false;
+    const auditedCharacters = chars.map((c) => {
+      const audited = namedCharacterForRole(c, `${fid}|${p.id}|normalize`);
+      if (audited !== c) changed = true;
+      return audited;
+    });
+
+    if (!changed) return p;
+    characterAuditTouched = true;
+    projectsTouched = true;
+    return {
+      ...(p as any),
+      script: {
+        ...(p as any).script,
+        characters: auditedCharacters,
+      },
+    } as Project;
+  });
+
   let scriptsTouched = false;
   const inputScripts = (state.scripts || []) as Script[];
   let nextScripts: Script[] = inputScripts.map((s) => {
@@ -242,14 +268,43 @@ export function normalizeFranchisesState(state: GameState): GameState {
   }
 
   let entriesTouched = false;
+  let libraryTouched = false;
   const nextFranchisesWithEntries = nextFranchises.map((f) => {
     const fromProjects = entriesFromProjects.get(f.id) || [];
     const merged = uniqStrings([...(f.entries || []), ...fromProjects]);
-    if (merged.length === (f.entries || []).length && merged.every((v, i) => v === (f.entries || [])[i])) {
-      return f;
-    }
-    entriesTouched = true;
-    return { ...f, entries: merged };
+    const projectsForFranchise = nextProjects.filter((p) => merged.includes(p.id));
+    const characterLibrary = buildCharacterLibrary(f, projectsForFranchise);
+    const talentLibrary = buildTalentLibrary(f, projectsForFranchise, state);
+    const continuity = {
+      ...(f.continuity || {}),
+      characterAppearances: Object.fromEntries(characterLibrary.map((c) => [c.characterId, c.appearances])),
+      timelineEvents: [
+        ...((f.continuity?.timelineEvents || []).filter((e) => e.type !== 'appearance')),
+        ...projectsForFranchise.map((p) => ({
+          id: `appearance-${p.id}`,
+          projectId: p.id,
+          description: `${p.title} entered the ${f.title} canon.`,
+          type: 'appearance' as const,
+        })),
+      ],
+      deaths: f.continuity?.deaths || {},
+      relationships: f.continuity?.relationships || [],
+      locations: f.continuity?.locations || [],
+      plotThreads: f.continuity?.plotThreads || [],
+      warnings: f.continuity?.warnings || [],
+    };
+    const bible = f.franchiseBible || {
+      worldbuilding: f.description ? [f.description] : [],
+      relationshipMap: characterLibrary.flatMap((c) => (c.relationships || []).map((r) => ({ fromCharacterId: c.characterId, toCharacterId: r.characterId, relationship: r.relationship }))),
+      sequelHooks: [`Track returning audience favorites from ${f.title}.`],
+      plannedArc: 'saga' as const,
+    };
+    const entriesChanged = merged.length !== (f.entries || []).length || !merged.every((v, i) => v === (f.entries || [])[i]);
+    const librariesChanged = characterLibrary.length !== (f.characterLibrary || []).length || talentLibrary.length !== (f.talentLibrary || []).length || !f.continuity || !f.franchiseBible;
+    if (entriesChanged) entriesTouched = true;
+    if (librariesChanged) libraryTouched = true;
+    if (!entriesChanged && !librariesChanged) return f;
+    return { ...f, entries: merged, characterLibrary, talentLibrary, continuity, franchiseBible: bible };
   });
 
   const inputFranchises = (state.franchises || []) as Franchise[];
@@ -258,7 +313,7 @@ export function normalizeFranchisesState(state: GameState): GameState {
     baseFranchises.length !== inputFranchises.length ||
     baseFranchises.some((f, i) => inputFranchises[i]?.id !== f.id);
 
-  const franchisesTouched = dedupeChanged || mergedByTitle || entriesTouched || canonicalizedParodySource;
+  const franchisesTouched = dedupeChanged || mergedByTitle || entriesTouched || libraryTouched || canonicalizedParodySource;
 
   if (!franchisesTouched && !projectsTouched && !scriptsTouched) return state;
 

--- a/src/utils/roleImport.ts
+++ b/src/utils/roleImport.ts
@@ -4,6 +4,7 @@ import { RoleDatabase } from '@/data/RoleDatabase';
 import { getEffectiveParodyCharacterNameMap } from '@/data/ParodyCharacterNames';
 import { stablePick } from '@/utils/stablePick';
 import { getRoleRequiredType } from '@/utils/scriptRoles';
+import { namedCharacterForRole } from '@/utils/franchiseContinuity';
 
 function toScriptCharacter(def: FranchiseCharacterDef, franchiseId?: string, parodySource?: string): ScriptCharacter {
   // Prefer recognizable names from parody source mapping when available
@@ -92,15 +93,36 @@ export function importRolesForScript(script: Script, gameState: GameState): Scri
         }
       }
     } else {
+      const library = franchise?.characterLibrary?.filter((c) => c.status === 'active') || [];
+      if (library.length > 0) {
+        library.forEach((entry) => {
+          const incoming: ScriptCharacter = {
+            id: entry.characterId,
+            name: entry.name,
+            description: entry.description,
+            importance: entry.narrativeImportance === 'lead' ? 'lead' : entry.narrativeImportance === 'supporting' || entry.narrativeImportance === 'recurring' ? 'supporting' : 'minor',
+            traits: entry.traits,
+            relationships: entry.relationships,
+            requiredType: 'actor',
+            ageRange: entry.ageRange,
+            requiredGender: entry.gender,
+            franchiseId: script.franchiseId,
+            franchiseCharacterId: entry.characterId,
+            locked: entry.narrativeImportance !== 'minor' && entry.narrativeImportance !== 'cameo',
+          };
+          const match = existing.find(c => c.franchiseCharacterId === incoming.franchiseCharacterId || (c.name === incoming.name && c.requiredType === incoming.requiredType));
+          if (!match) characters.push(incoming); else characters.push(mergeWithOverrides(match, incoming));
+        });
+      }
       // Fallback to curated role database
-      const fallback = RoleDatabase.getRolesForSource('franchise', script.franchiseId, gameState);
+      const fallback = library.length > 0 ? [] : RoleDatabase.getRolesForSource('franchise', script.franchiseId, gameState);
       fallback.forEach(role => {
-        const incoming: ScriptCharacter = {
+        const incoming: ScriptCharacter = namedCharacterForRole({
           ...role,
           franchiseId: script.franchiseId,
           franchiseCharacterId: role.id,
           locked: role.requiredType === 'director' ? true : (role.importance !== 'minor'),
-        };
+        }, `${script.franchiseId}|${script.id}`);
         const match = existing.find(c => c.franchiseCharacterId === incoming.franchiseCharacterId || (c.name === incoming.name && c.requiredType === incoming.requiredType));
         if (!match) characters.push(incoming); else characters.push(mergeWithOverrides(match, incoming));
       });
@@ -152,6 +174,7 @@ export function importRolesForScript(script: Script, gameState: GameState): Scri
   // Actor roles must always have a gender requirement.
   // (Imported roles often lack it, and casting filters now require it.)
   return finalList.map((role) => {
+    role = namedCharacterForRole(role, `${script.franchiseId || script.publicDomainId || script.id}|import`);
     const requiredType = getRoleRequiredType(role);
 
     if (requiredType === 'director') {

--- a/src/utils/sequelScripts.ts
+++ b/src/utils/sequelScripts.ts
@@ -34,6 +34,16 @@ export function createSequelScript(params: {
 
   const pacing = isTv ? 'episodic' : 'fast-paced';
 
+  const confirmedReturning = returningCast.length > 0
+    ? returningCast
+    : (base?.characters || [])
+        .filter((char) => char.assignedTalentId && (char.importance === 'lead' || char.importance === 'supporting' || char.importance === 'crew'))
+        .map((char) => ({ characterId: getCharacterKey(char), talentId: char.assignedTalentId!, confirmed: true }));
+
+  const continuityNotes = (originalProject.contractedTalent || [])
+    .filter((t) => ['Director', 'Writer', 'Producer'].includes(t.role))
+    .map((t) => `Returning ${t.role} hold: ${t.talentId}`);
+
   return {
     id,
     title,
@@ -44,7 +54,6 @@ export function createSequelScript(params: {
     quality: Math.max(60, (base?.quality || 70) - 5),
     budget,
     developmentStage: 'concept',
-    themes: base?.themes || ['adventure', 'friendship'],
     targetAudience: base?.targetAudience || 'general',
     estimatedRuntime,
     characteristics: {
@@ -60,9 +69,10 @@ export function createSequelScript(params: {
     characters: (base?.characters || []).map((char) => ({
       ...char,
       assignedTalentId:
-        returningCast.find((cast) => cast.characterId === getCharacterKey(char) && cast.confirmed)?.talentId ||
+        confirmedReturning.find((cast) => cast.characterId === getCharacterKey(char) && cast.confirmed)?.talentId ||
         undefined,
     })),
+    themes: Array.from(new Set([...(base?.themes || ['adventure', 'friendship']), ...continuityNotes])),
     franchiseId,
     sourceType: 'franchise',
   };

--- a/tests/franchiseNormalization.test.ts
+++ b/tests/franchiseNormalization.test.ts
@@ -134,4 +134,45 @@ describe('normalizeFranchisesState', () => {
     expect(normalized.franchises).toHaveLength(1);
     expect(normalized.franchises[0].parodySource).toBe('Voidborne');
   });
+
+  it('audits franchise entries into persistent character, talent, bible, and continuity libraries', () => {
+    const base = {
+      universeSeed: 1,
+      rngState: 1,
+      studio: { id: 'studio-1', name: 'You' },
+      currentYear: 2000,
+      currentWeek: 1,
+      currentQuarter: 1,
+      talent: [{ id: 'talent-1', name: 'Star Performer', contractStatus: 'available' }],
+      projects: [{
+        id: 'p1',
+        title: 'Origin',
+        franchiseId: 'f-a',
+        contractedTalent: [],
+        script: {
+          id: 's1',
+          title: 'Origin',
+          franchiseId: 'f-a',
+          characters: [
+            { id: 'hero', name: 'Hero', importance: 'lead', requiredType: 'actor', requiredGender: 'Male', assignedTalentId: 'talent-1' },
+            { id: 'cameo', name: 'Background Extra', importance: 'minor', requiredType: 'actor', requiredGender: 'Female' },
+          ],
+        },
+      }],
+      scripts: [],
+      franchises: [{ id: 'f-a', title: 'My Universe', creatorStudioId: 'studio-1', entries: ['p1'] }],
+    } as any;
+
+    const normalized = normalizeFranchisesState(base);
+    const franchise = normalized.franchises[0] as any;
+
+    expect(franchise.characterLibrary).toHaveLength(1);
+    expect(franchise.characterLibrary[0].name).not.toBe('Hero');
+    expect((normalized.projects[0] as any).script.characters[0].name).not.toBe('Hero');
+    expect(franchise.characterLibrary[0].ageRange).toEqual([25, 45]);
+    expect(franchise.characterLibrary[0].recurrencePotential).toBeGreaterThan(90);
+    expect(franchise.talentLibrary[0].talentId).toBe('talent-1');
+    expect(franchise.continuity.characterAppearances[franchise.characterLibrary[0].characterId]).toEqual(['p1']);
+    expect(franchise.franchiseBible.sequelHooks.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/roleImport.test.ts
+++ b/tests/roleImport.test.ts
@@ -266,4 +266,56 @@ describe('importRolesForScript', () => {
     const importedAgain = importRolesForScript({ ...script, characters: imported }, gameState);
     expect(importedAgain).toHaveLength(imported.length);
   });
+
+  it('imports active franchise character library entries and excludes retired or deceased canon entries', () => {
+    const franchise: Franchise = {
+      id: 'f-library',
+      title: 'Library Saga',
+      originDate: '2024-01-01',
+      creatorStudioId: 'studio-1',
+      genre: ['drama'],
+      tone: 'serious',
+      entries: [],
+      status: 'active',
+      franchiseTags: [],
+      culturalWeight: 50,
+      cost: 0,
+      characterLibrary: [
+        {
+          characterId: 'active-hero',
+          name: 'Mara Vale',
+          ageRange: [30, 40],
+          gender: 'Female',
+          description: 'Continuing protagonist',
+          narrativeImportance: 'lead',
+          recurrencePotential: 95,
+          status: 'active',
+          appearances: ['p-1'],
+        },
+        {
+          characterId: 'dead-mentor',
+          name: 'Elias Reed',
+          ageRange: [60, 75],
+          gender: 'Male',
+          description: 'Canonically dead mentor',
+          narrativeImportance: 'supporting',
+          recurrencePotential: 50,
+          status: 'deceased',
+          appearances: ['p-1'],
+        },
+      ],
+    };
+
+    const gameState = makeBaseGameState({ franchises: [franchise] });
+    const script = makeBaseScript({
+      sourceType: 'franchise',
+      franchiseId: franchise.id,
+      characters: [],
+    });
+
+    const imported = importRolesForScript(script, gameState);
+
+    expect(imported.some((c) => c.franchiseCharacterId === 'active-hero' && c.name === 'Mara Vale')).toBe(true);
+    expect(imported.some((c) => c.franchiseCharacterId === 'dead-mentor')).toBe(false);
+  });
 });

--- a/tests/sequelScripts.test.ts
+++ b/tests/sequelScripts.test.ts
@@ -73,4 +73,21 @@ describe('createSequelScript', () => {
     expect(script.estimatedRuntime).toBe(130);
     expect(script.characteristics.pacing).toBe('fast-paced');
   });
+
+  it('automatically carries forward established cast when no manual returning cast list is supplied', () => {
+    const script = createSequelScript({
+      id: 's-4',
+      title: 'Original III',
+      description: 'Continuation',
+      budget: 35_000_000,
+      franchiseId: 'f-1',
+      medium: 'film',
+      originalProject: baseProject,
+      returningCast: [],
+      getCharacterKey: (c) => c.id,
+    });
+
+    expect(script.characters?.find((c: any) => c.id === 'c-1')?.assignedTalentId).toBe('a-1');
+    expect(script.characters?.find((c: any) => c.id === 'c-2')?.assignedTalentId).toBe('a-2');
+  });
 });


### PR DESCRIPTION
### Motivation

- Introduce persistent franchise continuity and planning data so franchises can track characters, talent, and canon across entries.  
- Surface continuity intelligence and editable franchise dashboards in the UI to help manage long-running IPs.  
- Ensure imported roles and normalization pipeline produce stable named characters and libraries for sequels and script tooling.

### Description

- Added new persistence and types in `src/types/game.ts` for `FranchiseCharacterLibraryEntry`, `FranchiseTalentLibraryEntry`, `FranchiseContinuityDatabase`, and `FranchiseBible` and extended `Franchise` with these fields.  
- Implemented `src/utils/franchiseContinuity.ts` with helpers to build character/talent libraries and generate stable names via `namedCharacterForRole`.  
- Enhanced normalization in `src/utils/franchiseNormalization.ts` to audit franchise projects and automatically build `characterLibrary`, `talentLibrary`, `continuity`, and `franchiseBible` entries for franchises.  
- Updated role import in `src/utils/roleImport.ts` to prefer active `characterLibrary` entries when present and to call `namedCharacterForRole` for stable naming.  
- Updated sequel generation in `src/utils/sequelScripts.ts` to auto-carry returning cast when no explicit `returningCast` is supplied and to add continuity notes to `themes`.  
- Extended UI components (`EnhancedFranchiseSystem.tsx`, `FranchiseManagementSystem.tsx`, `OwnedFranchiseManager.tsx`, `SequelManagement.tsx`) to populate new franchise fields on creation and to add a franchise dashboard with character/talent lists and controls (`promoteCharacter`, `updateCharacterStatus`, and `getFranchiseIntelligence`).

### Testing

- Ran unit tests in `tests/franchiseNormalization.test.ts` which assert library/audit behavior and `franchiseBible` population and the test suite passed.  
- Ran `tests/roleImport.test.ts` which verifies importing active library entries and exclusion of deceased/retired characters and the test passed.  
- Ran `tests/sequelScripts.test.ts` which verifies sequel script generation and automatic carry-forward of cast and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed39485688322975517fe8af90640)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Franchise Dashboard with character and talent library management.
  * Introduced Continuity tracking for timelines, relationships, deaths, locations, and plot threads.
  * Added Franchise Bible for worldbuilding and sequel planning.
  * Enhanced character status management with new lifecycle states.
  * Added Franchise Intelligence recommendations based on franchise metrics.

* **Improvements**
  * Improved sequel creation with automatic returning cast tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->