### PR TITLE
Add bid parsing/formatting & UI improvements for festival marketplace; improve franchise continuity popularity and role import handling

### DIFF
--- a/src/components/game/FestivalManagement.tsx
+++ b/src/components/game/FestivalManagement.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { getFestivalById, getFestivalByWeek, getFestivalOptions } from '@/data/Festivals';
-import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds } from '@/utils/festivalMarketplace';
+import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
 import { FinancialEngine } from './FinancialEngine';
 import type { Project } from '@/types/game';
 
@@ -29,14 +29,14 @@ export const FestivalManagement: React.FC = () => {
     currentFestival?.id ?? festivalOptions[0]?.id ?? ''
   );
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [bidAmount, setBidAmount] = useState<number>(0);
+  const [bidInput, setBidInput] = useState<string>('');
   const [auctionPreview, setAuctionPreview] = useState<any | null>(null);
 
   useEffect(() => {
     if (currentFestival?.id && currentFestival.id !== selectedFestivalId) {
       setSelectedFestivalId(currentFestival.id);
       setSelectedProjectId(null);
-      setBidAmount(0);
+      setBidInput('');
       setAuctionPreview(null);
     }
   }, [currentFestival?.id, selectedFestivalId]);
@@ -58,6 +58,7 @@ export const FestivalManagement: React.FC = () => {
     () => projects.find((project) => project.id === selectedProjectId) || null,
     [projects, selectedProjectId]
   );
+  const bidAmount = parseFestivalBidAmount(bidInput);
 
   const handleAuctionPreview = () => {
     if (!selected || !gameState) return;
@@ -91,7 +92,7 @@ export const FestivalManagement: React.FC = () => {
 
     toast({ title: 'Acquired Rights', description: `You acquired ${selected.title} for ${(bidAmount / 1000000).toFixed(2)}M.` });
     setSelectedProjectId(null);
-    setBidAmount(0);
+    setBidInput('');
     setAuctionPreview(null);
   };
 
@@ -116,7 +117,7 @@ export const FestivalManagement: React.FC = () => {
                     onClick={() => {
                       setSelectedFestivalId(fest.id);
                       setSelectedProjectId(null);
-                      setBidAmount(0);
+                      setBidInput('');
                       setAuctionPreview(null);
                     }}
                   >
@@ -195,7 +196,17 @@ export const FestivalManagement: React.FC = () => {
 
                 <div>
                   <label className="text-sm text-muted-foreground">Bid Amount</label>
-                  <Input type="number" value={bidAmount || ''} onChange={(event) => setBidAmount(Number(event.target.value) || 0)} />
+                  <Input
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="$2.5M or 2500000"
+                    value={bidInput}
+                    onChange={(event) => { setBidInput(event.target.value); setAuctionPreview(null); }}
+                  />
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    Enter dollars exactly, or use shorthand: <span className="font-medium">$2.5M</span>, <span className="font-medium">2.5 million</span>, or <span className="font-medium">2500000</span>.
+                    {bidAmount > 0 && <> Parsed offer: {formatFestivalBidAmount(bidAmount)}.</>}
+                  </div>
                 </div>
 
                 <div className="grid gap-2">
@@ -246,6 +257,11 @@ export const FestivalManagement: React.FC = () => {
                     <div className="mt-2 text-xs text-muted-foreground">
                       {auctionPreview.userWins ? 'Your current offer would win.' : 'Your current offer would be outbid.'}
                     </div>
+                    {!auctionPreview.userWins && (
+                      <Button size="sm" variant="outline" className="mt-3" onClick={() => setBidInput(formatFestivalBidAmount(auctionPreview.requiredToWin))}>
+                        Use minimum winning bid
+                      </Button>
+                    )}
                   </div>
                 </div>
               </CardContent>

--- a/src/components/game/FestivalMarketplaceModal.tsx
+++ b/src/components/game/FestivalMarketplaceModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { useGameStore } from '@/game/store';
-import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds } from '@/utils/festivalMarketplace';
+import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
 import { getFestivalById } from '@/data/Festivals';
 import { FinancialEngine } from './FinancialEngine';
 
@@ -26,7 +26,7 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
 
   const { toast } = useToast();
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [bidAmount, setBidAmount] = useState<number>(0);
+  const [bidInput, setBidInput] = useState<string>('');
   const [auctionPreview, setAuctionPreview] = useState<any | null>(null);
 
   const festival = getFestivalById(festivalId);
@@ -37,6 +37,7 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
   }, [gameState, festivalId]);
 
   const selected = projects.find((p) => p.id === selectedProjectId) || null;
+  const bidAmount = parseFestivalBidAmount(bidInput);
 
   const handlePreview = () => {
     if (!selected || !gameState) return;
@@ -79,7 +80,7 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
 
     toast({ title: 'Acquired Rights', description: `You acquired ${selected.title} for ${(bidAmount / 1000000).toFixed(2)}M` });
     setSelectedProjectId(null);
-    setBidAmount(0);
+    setBidInput('');
     setAuctionPreview(null);
     onOpenChange(false);
   };
@@ -145,7 +146,17 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
                   <div className="sm:col-span-2">
                     <label className="text-sm text-muted-foreground">Offer Amount (USD)</label>
-                    <Input type="number" value={String(bidAmount || '')} onChange={(e) => setBidAmount(Number(e.target.value) || 0)} />
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="$2.5M or 2500000"
+                      value={bidInput}
+                      onChange={(e) => { setBidInput(e.target.value); setAuctionPreview(null); }}
+                    />
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Enter dollars exactly, or use shorthand: <span className="font-medium">$2.5M</span>, <span className="font-medium">2.5 million</span>, or <span className="font-medium">2500000</span>.
+                      {bidAmount > 0 && <> Parsed offer: {formatFestivalBidAmount(bidAmount)}.</>}
+                    </div>
                   </div>
                   <div className="text-right">
                     <div className="flex flex-col gap-2">
@@ -188,6 +199,11 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
                     <div className="text-sm">Final highest: ${(auctionPreview.finalHighest / 1000000).toFixed(3)}M</div>
                     <div className="text-sm">Minimum to win: ${(auctionPreview.requiredToWin / 1000000).toFixed(3)}M</div>
                     <div className="text-sm">You {auctionPreview.userWins ? 'would win' : 'would be outbid'} with your current offer.</div>
+                    {!auctionPreview.userWins && (
+                      <Button size="sm" variant="outline" className="mt-2" onClick={() => setBidInput(formatFestivalBidAmount(auctionPreview.requiredToWin))}>
+                        Use minimum winning bid
+                      </Button>
+                    )}
                   </div>
                 </div>
               </CardContent>

--- a/src/utils/festivalMarketplace.ts
+++ b/src/utils/festivalMarketplace.ts
@@ -82,6 +82,34 @@ export function createPurchasePatch(
   return patch;
 }
 
+export function parseFestivalBidAmount(value: string | number): number {
+  if (typeof value === 'number') return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[$,\s]/g, '');
+
+  if (!normalized) return 0;
+
+  const match = normalized.match(/^(\d+(?:\.\d+)?)(m|million|k|thousand)?$/);
+  if (!match) return 0;
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount)) return 0;
+
+  const suffix = match[2];
+  const multiplier = suffix === 'm' || suffix === 'million' ? 1_000_000 : suffix === 'k' || suffix === 'thousand' ? 1_000 : 1;
+  return Math.max(0, Math.round(amount * multiplier));
+}
+
+export function formatFestivalBidAmount(amount: number): string {
+  if (!Number.isFinite(amount) || amount <= 0) return '';
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(3)}M`;
+  if (amount >= 1_000) return `$${(amount / 1_000).toFixed(1)}K`;
+  return `$${Math.round(amount).toLocaleString()}`;
+}
+
 // Multi-round auction simulation with simple genre biasing. Returns round-by-round rival bids,
 // the final highest rival offer, whether the `userOffer` wins, and a suggested minimum to win.
 export function runFestivalAuctionRounds(

--- a/src/utils/franchiseContinuity.ts
+++ b/src/utils/franchiseContinuity.ts
@@ -27,6 +27,34 @@ export function namedCharacterForRole(role: ScriptCharacter, seed: string): Scri
   };
 }
 
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function projectAudienceSignal(project: Project): number {
+  const metrics = project.metrics;
+  const audienceScore = typeof metrics?.audienceScore === 'number' ? metrics.audienceScore : 50;
+  const criticsScore = typeof metrics?.criticsScore === 'number' ? metrics.criticsScore : 50;
+  const boxOfficeTotal = typeof metrics?.boxOfficeTotal === 'number' ? metrics.boxOfficeTotal : 0;
+  const boxOfficeBonus = Math.min(12, boxOfficeTotal / 50_000_000);
+
+  return ((audienceScore * 0.65) + (criticsScore * 0.35) + boxOfficeBonus) - 50;
+}
+
+function nextPopularity(
+  prev: FranchiseCharacterLibraryEntry | undefined,
+  character: ScriptCharacter,
+  project: Project,
+  appearances: string[],
+): number {
+  const baseline = prev?.popularity ?? (character.importance === 'lead' ? 62 : character.importance === 'supporting' ? 50 : 42);
+  const importanceBonus = character.importance === 'lead' ? 8 : character.importance === 'supporting' ? 4 : 1;
+  const recurrenceBonus = Math.min(10, appearances.length * 2);
+  const audienceSignal = projectAudienceSignal(project) * (character.importance === 'lead' ? 0.35 : 0.2);
+
+  return clampScore((baseline * 0.72) + importanceBonus + recurrenceBonus + audienceSignal);
+}
+
 function characterIdFor(c: ScriptCharacter): string {
   return c.franchiseCharacterId || c.roleTemplateId || c.id || c.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
@@ -54,7 +82,7 @@ export function buildCharacterLibrary(franchise: Franchise, projects: Project[] 
         relationships: c.relationships || prev?.relationships,
         firstAppearanceProjectId: prev?.firstAppearanceProjectId || project.id,
         appearances,
-        popularity: prev?.popularity,
+        popularity: nextPopularity(prev, c, project, appearances),
       });
     }
   }

--- a/src/utils/roleImport.ts
+++ b/src/utils/roleImport.ts
@@ -1,4 +1,4 @@
-import { GameState, Script, ScriptCharacter, Gender } from '@/types/game';
+import type { GameState, Script, ScriptCharacter, Gender, FranchiseCharacterLibraryEntry } from '@/types/game';
 import { FranchiseCharacterDef, getEffectiveFranchiseCharacterDB } from '@/data/FranchiseCharacterDB';
 import { RoleDatabase } from '@/data/RoleDatabase';
 import { getEffectiveParodyCharacterNameMap } from '@/data/ParodyCharacterNames';
@@ -27,6 +27,38 @@ function toScriptCharacter(def: FranchiseCharacterDef, franchiseId?: string, par
     franchiseCharacterId: def.character_id,
     roleTemplateId: def.role_template_id,
     locked: true,
+  };
+}
+
+function toScriptCharacterFromLibrary(entry: FranchiseCharacterLibraryEntry, franchiseId: string): ScriptCharacter {
+  return {
+    id: entry.characterId,
+    name: entry.name,
+    description: entry.description,
+    importance: entry.narrativeImportance === 'lead' ? 'lead' : entry.narrativeImportance === 'supporting' || entry.narrativeImportance === 'recurring' ? 'supporting' : 'minor',
+    traits: entry.traits,
+    relationships: entry.relationships,
+    requiredType: 'actor',
+    ageRange: entry.ageRange,
+    requiredGender: entry.gender,
+    franchiseId,
+    franchiseCharacterId: entry.characterId,
+    locked: entry.narrativeImportance !== 'minor' && entry.narrativeImportance !== 'cameo',
+  };
+}
+
+function applyLibraryContinuity(incoming: ScriptCharacter, entry?: FranchiseCharacterLibraryEntry): ScriptCharacter {
+  if (!entry) return incoming;
+
+  return {
+    ...incoming,
+    name: entry.name || incoming.name,
+    description: entry.description || incoming.description,
+    traits: entry.traits || incoming.traits,
+    relationships: entry.relationships || incoming.relationships,
+    ageRange: entry.ageRange || incoming.ageRange,
+    requiredGender: entry.gender || incoming.requiredGender,
+    locked: entry.narrativeImportance !== 'minor' && entry.narrativeImportance !== 'cameo',
   };
 }
 
@@ -82,9 +114,17 @@ export function importRolesForScript(script: Script, gameState: GameState): Scri
       defs = characterDb[franchise.parodySource];
     }
 
+    const activeLibrary = franchise?.characterLibrary?.filter((c) => c.status === 'active') || [];
+    const libraryById = new Map(activeLibrary.map((entry) => [entry.characterId, entry]));
+    const importedCharacterIds = new Set<string>();
+
     if (defs && defs.length > 0) {
       for (const def of defs) {
-        const incoming = toScriptCharacter(def, script.franchiseId, franchise?.parodySource);
+        const libraryEntry = libraryById.get(def.character_id);
+        if (franchise?.characterLibrary?.some((entry) => entry.characterId === def.character_id && entry.status !== 'active')) continue;
+
+        const incoming = applyLibraryContinuity(toScriptCharacter(def, script.franchiseId, franchise?.parodySource), libraryEntry);
+        importedCharacterIds.add(def.character_id);
         const match = existing.find(c => c.franchiseCharacterId === def.character_id || (c.name === incoming.name && c.requiredType === def.requiredType));
         if (!match) {
           characters.push(incoming);
@@ -92,24 +132,18 @@ export function importRolesForScript(script: Script, gameState: GameState): Scri
           characters.push(mergeWithOverrides(match, incoming));
         }
       }
+
+      for (const entry of activeLibrary) {
+        if (importedCharacterIds.has(entry.characterId)) continue;
+        const incoming = toScriptCharacterFromLibrary(entry, script.franchiseId);
+        const match = existing.find(c => c.franchiseCharacterId === incoming.franchiseCharacterId || (c.name === incoming.name && c.requiredType === incoming.requiredType));
+        if (!match) characters.push(incoming); else characters.push(mergeWithOverrides(match, incoming));
+      }
     } else {
-      const library = franchise?.characterLibrary?.filter((c) => c.status === 'active') || [];
+      const library = activeLibrary;
       if (library.length > 0) {
         library.forEach((entry) => {
-          const incoming: ScriptCharacter = {
-            id: entry.characterId,
-            name: entry.name,
-            description: entry.description,
-            importance: entry.narrativeImportance === 'lead' ? 'lead' : entry.narrativeImportance === 'supporting' || entry.narrativeImportance === 'recurring' ? 'supporting' : 'minor',
-            traits: entry.traits,
-            relationships: entry.relationships,
-            requiredType: 'actor',
-            ageRange: entry.ageRange,
-            requiredGender: entry.gender,
-            franchiseId: script.franchiseId,
-            franchiseCharacterId: entry.characterId,
-            locked: entry.narrativeImportance !== 'minor' && entry.narrativeImportance !== 'cameo',
-          };
+          const incoming = toScriptCharacterFromLibrary(entry, script.franchiseId);
           const match = existing.find(c => c.franchiseCharacterId === incoming.franchiseCharacterId || (c.name === incoming.name && c.requiredType === incoming.requiredType));
           if (!match) characters.push(incoming); else characters.push(mergeWithOverrides(match, incoming));
         });

--- a/tests/festivalMarketplace.test.ts
+++ b/tests/festivalMarketplace.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { formatFestivalBidAmount, parseFestivalBidAmount } from '@/utils/festivalMarketplace';
+
+describe('festival marketplace bidding helpers', () => {
+  it('parses exact dollar and shorthand bid formats', () => {
+    expect(parseFestivalBidAmount('2500000')).toBe(2_500_000);
+    expect(parseFestivalBidAmount('2,500,000')).toBe(2_500_000);
+    expect(parseFestivalBidAmount('$2.5M')).toBe(2_500_000);
+    expect(parseFestivalBidAmount('2.5 million')).toBe(2_500_000);
+    expect(parseFestivalBidAmount('750k')).toBe(750_000);
+  });
+
+  it('rejects ambiguous or invalid bid input instead of silently underbidding', () => {
+    expect(parseFestivalBidAmount('2.5mm')).toBe(0);
+    expect(parseFestivalBidAmount('abc')).toBe(0);
+    expect(parseFestivalBidAmount('')).toBe(0);
+  });
+
+  it('formats suggested winning bids back into an easy editable input string', () => {
+    expect(formatFestivalBidAmount(2_500_000)).toBe('$2.500M');
+    expect(formatFestivalBidAmount(750_000)).toBe('$750.0K');
+  });
+});

--- a/tests/franchiseNormalization.test.ts
+++ b/tests/franchiseNormalization.test.ts
@@ -149,6 +149,7 @@ describe('normalizeFranchisesState', () => {
         title: 'Origin',
         franchiseId: 'f-a',
         contractedTalent: [],
+        metrics: { audienceScore: 92, criticsScore: 88, boxOfficeTotal: 300_000_000 },
         script: {
           id: 's1',
           title: 'Origin',
@@ -171,6 +172,7 @@ describe('normalizeFranchisesState', () => {
     expect((normalized.projects[0] as any).script.characters[0].name).not.toBe('Hero');
     expect(franchise.characterLibrary[0].ageRange).toEqual([25, 45]);
     expect(franchise.characterLibrary[0].recurrencePotential).toBeGreaterThan(90);
+    expect(franchise.characterLibrary[0].popularity).toBeGreaterThan(60);
     expect(franchise.talentLibrary[0].talentId).toBe('talent-1');
     expect(franchise.continuity.characterAppearances[franchise.characterLibrary[0].characterId]).toEqual(['p1']);
     expect(franchise.franchiseBible.sequelHooks.length).toBeGreaterThan(0);

--- a/tests/roleImport.test.ts
+++ b/tests/roleImport.test.ts
@@ -318,4 +318,73 @@ describe('importRolesForScript', () => {
     expect(imported.some((c) => c.franchiseCharacterId === 'active-hero' && c.name === 'Mara Vale')).toBe(true);
     expect(imported.some((c) => c.franchiseCharacterId === 'dead-mentor')).toBe(false);
   });
+
+  it('keeps curated franchise roles in sync with the character library and imports added canon characters', () => {
+    const franchise: Franchise = {
+      id: 'f-library-db',
+      title: 'Space Saga',
+      originDate: '2024-01-01',
+      creatorStudioId: 'studio-1',
+      genre: ['sci-fi'],
+      tone: 'epic',
+      parodySource: 'Star Saga',
+      entries: [],
+      status: 'active',
+      franchiseTags: [],
+      culturalWeight: 50,
+      cost: 0,
+      characterLibrary: [
+        {
+          characterId: 'char_hero_pilot',
+          name: 'Captain Mara Vale',
+          ageRange: [35, 45],
+          gender: 'Female',
+          description: 'Library-updated franchise lead.',
+          narrativeImportance: 'lead',
+          recurrencePotential: 99,
+          status: 'active',
+          appearances: ['p-1'],
+        },
+        {
+          characterId: 'char_wise_mentor',
+          name: 'Retired Mentor',
+          ageRange: [65, 80],
+          gender: 'Male',
+          description: 'Retired from the franchise.',
+          narrativeImportance: 'supporting',
+          recurrencePotential: 30,
+          status: 'retired',
+          appearances: ['p-1'],
+        },
+        {
+          characterId: 'char_new_ally',
+          name: 'Nora Cross',
+          ageRange: [28, 38],
+          gender: 'Female',
+          description: 'Original ally introduced in the previous installment.',
+          narrativeImportance: 'supporting',
+          recurrencePotential: 85,
+          status: 'active',
+          appearances: ['p-1'],
+        },
+      ],
+    };
+
+    const gameState = makeBaseGameState({ franchises: [franchise] });
+    const script = makeBaseScript({
+      sourceType: 'franchise',
+      franchiseId: franchise.id,
+      characters: [],
+    });
+
+    const imported = importRolesForScript(script, gameState);
+
+    const hero = imported.find((c) => c.franchiseCharacterId === 'char_hero_pilot');
+    expect(hero?.name).toBe('Captain Mara Vale');
+    expect(hero?.description).toBe('Library-updated franchise lead.');
+    expect(hero?.requiredGender).toBe('Female');
+    expect(imported.some((c) => c.franchiseCharacterId === 'char_wise_mentor')).toBe(false);
+    expect(imported.some((c) => c.franchiseCharacterId === 'char_new_ally' && c.name === 'Nora Cross')).toBe(true);
+    expect(imported.some((c) => c.requiredType === 'director')).toBe(true);
+  });
 });


### PR DESCRIPTION
### Motivation
- Make festival bid entry robust and user-friendly by accepting shorthand inputs (e.g. `$2.5M`, `2.5 million`) and showing a parsed preview. 
- Provide a convenient way to apply the minimum winning bid suggested by auction previews. 
- Improve franchise continuity by computing a more meaningful popularity score for character library entries and better applying the library during role import.

### Description
- Add `parseFestivalBidAmount` and `formatFestivalBidAmount` to `src/utils/festivalMarketplace.ts` and use them to accept freeform bid input via a string `bidInput` state and display a parsed offer in `FestivalManagement` and `FestivalMarketplaceModal`. 
- Replace numeric-only bid inputs with text inputs (`inputMode="decimal"`) and add a "Use minimum winning bid" button in auction previews that formats and injects the suggested amount. 
- Introduce `projectAudienceSignal`, `nextPopularity`, and `clampScore` in `src/utils/franchiseContinuity.ts` and use `nextPopularity` to set `popularity` when building the franchise character library. 
- Enhance `src/utils/roleImport.ts` with `toScriptCharacterFromLibrary` and `applyLibraryContinuity`, prefer active library entries, skip non-active entries, and merge library-continuity data into imported script characters. 
- Add unit tests for bid parsing/formatting (`tests/festivalMarketplace.test.ts`) and expand tests that rely on franchise normalization and role import behavior (`tests/franchiseNormalization.test.ts`, `tests/roleImport.test.ts`).

### Testing
- Ran the test suite with `vitest`; `festivalMarketplace.test.ts` validates parsing and formatting helpers and passed. 
- Updated franchise normalization tests (`franchiseNormalization.test.ts`) to assert computed `popularity` and they passed. 
- Extended role import tests (`roleImport.test.ts`) that validate library sync and import behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3580d9550083229d67bb5f1d3b56ad)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Festival bid input now supports shorthand formats ($2.5M, "2.5 million", etc.) and displays parsed offer in real-time.
  * Added "Use minimum winning bid" button to auto-fill the required amount when at risk of losing a bid.

* **Improvements**
  * Enhanced character popularity scoring with project metrics and character context integration.

* **Tests**
  * Added comprehensive test coverage for bid utilities and role import synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->