### PR TITLE
Extend talent contracts, festival acquisition flow, franchise creation UI, and sequel continuity import

### DIFF
--- a/src/components/game/CharacterCastingSystem.tsx
+++ b/src/components/game/CharacterCastingSystem.tsx
@@ -117,7 +117,7 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
     setNegotiationTarget({ character, talent });
   };
 
-  const finalizeAssignment = (result: { interestScore: number; askWeeklyPay: number; weeklyPay: number; contractWeeks: number }) => {
+  const finalizeAssignment = (result: { interestScore: number; askWeeklyPay: number; weeklyPay: number; contractWeeks: number; contractScope?: 'project' | 'multi-picture' | 'exclusive'; sequelOptions?: number; exclusivity?: boolean; merchandising?: boolean }) => {
     if (!negotiationTarget) return;
 
     const { character, talent } = negotiationTarget;
@@ -135,6 +135,10 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
             askWeeklyPay: result.askWeeklyPay,
             negotiatedWeek: gameState.currentWeek,
             negotiatedYear: gameState.currentYear,
+            contractScope: result.contractScope || 'project',
+            sequelOptions: result.sequelOptions ?? 0,
+            exclusivity: result.exclusivity ?? false,
+            merchandising: result.merchandising ?? false,
           }
         }
         : c
@@ -220,9 +224,11 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
 
     const isFranchiseProject = !!project.script?.franchiseId;
 
-    const negotiatedByTalentId = new Map<string, { weeklyPay: number; contractWeeks: number; interestLabel: string; interestScore: number }>();
+    type SlotDeal = { weeklyPay: number; contractWeeks: number; askWeeklyPay?: number; interestLabel?: string; interestScore: number; contractScope?: 'project' | 'multi-picture' | 'exclusive'; sequelOptions?: number; exclusivity?: boolean; merchandising?: boolean };
 
-    const getSlotDeal = (slot: CastingSlot) => {
+    const negotiatedBySlotId = new Map<string, SlotDeal>();
+
+    const getSlotDeal = (slot: CastingSlot): SlotDeal | null => {
       if (slot.character.negotiatedContract) return slot.character.negotiatedContract;
       if (!slot.talent) return null;
 
@@ -279,11 +285,15 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
       const interest = describeTalentInterest(deal.interestScore);
       requiredCashTotal += deal.weeklyPay * Math.min(4, deal.contractWeeks);
 
-      negotiatedByTalentId.set(slot.talent.id, {
+      negotiatedBySlotId.set(slot.character.id, {
         weeklyPay: deal.weeklyPay,
         contractWeeks: deal.contractWeeks,
         interestLabel: interest.label,
         interestScore: deal.interestScore,
+        contractScope: deal.contractScope,
+        sequelOptions: deal.sequelOptions,
+        exclusivity: deal.exclusivity,
+        merchandising: deal.merchandising,
       });
     }
 
@@ -299,7 +309,7 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
     // Directors belong in crew; only actors belong in cast.
     const castEntries = actorSlots.map(s => {
       const talent = s.talent as TalentPerson;
-      const deal = negotiatedByTalentId.get(talent.id)!;
+      const deal = negotiatedBySlotId.get(s.character.id)!
       const contractWeeks = deal.contractWeeks;
 
       return {
@@ -311,16 +321,16 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
         points: 10,
         contractTerms: {
           duration: new Date(Date.now() + contractWeeks * 7 * 24 * 60 * 60 * 1000),
-          exclusivity: true,
-          merchandising: true,
-          sequelOptions: isFranchiseProject && s.character.importance === 'lead' ? 2 : 1
+          exclusivity: deal.exclusivity ?? true,
+          merchandising: deal.merchandising ?? (s.character.importance === 'lead'),
+          sequelOptions: deal.sequelOptions ?? (isFranchiseProject && s.character.importance === 'lead' ? 2 : 1)
         }
       };
     });
 
     const crewEntries = directorSlots.map(s => {
       const talent = s.talent as TalentPerson;
-      const deal = negotiatedByTalentId.get(talent.id)!;
+      const deal = negotiatedBySlotId.get(s.character.id)!
       const contractWeeks = deal.contractWeeks;
 
       return {
@@ -330,9 +340,9 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
         points: 15,
         contractTerms: {
           duration: new Date(Date.now() + contractWeeks * 7 * 24 * 60 * 60 * 1000),
-          exclusivity: true,
-          merchandising: true,
-          sequelOptions: 1
+          exclusivity: deal.exclusivity ?? true,
+          merchandising: deal.merchandising ?? true,
+          sequelOptions: deal.sequelOptions ?? 1
         }
       };
     });
@@ -347,16 +357,18 @@ export const CharacterCastingSystem: React.FC<CharacterCastingSystemProps> = ({
 const totalCost = slots
   .filter(s => s.talent)
   .reduce((sum, s) => {
-    const deal = negotiatedByTalentId.get((s.talent as TalentPerson).id);
+    const deal = negotiatedBySlotId.get(s.character.id);
     if (!deal) return sum;
     return sum + deal.weeklyPay * deal.contractWeeks;
   }, 0);
 
+const isMajorContractSlot = (slot: CastingSlot) => isDirectorRole(slot.character) || slot.character.importance === 'lead' || slot.character.importance === 'supporting';
+
 const contracted = slots
-  .filter(s => s.talent)
+  .filter(s => s.talent && isMajorContractSlot(s))
   .map(s => {
     const talent = s.talent as TalentPerson;
-    const deal = negotiatedByTalentId.get(talent.id)!;
+    const deal = negotiatedBySlotId.get(s.character.id)!
     const requiredType = isDirectorRole(s.character) ? 'director' : 'actor';
 
     return {
@@ -369,17 +381,24 @@ const contracted = slots
       weeklyPay: deal.weeklyPay,
       contractWeeks: deal.contractWeeks,
       weeksRemaining: deal.contractWeeks,
-      startWeek: gameState.currentWeek
+      startWeek: gameState.currentWeek,
+      projectId: project.id,
+      characterId: s.character.franchiseCharacterId || s.character.id,
+      roleType: requiredType,
+      contractScope: deal.contractScope || 'project',
+      sequelOptions: deal.sequelOptions ?? (isFranchiseProject && s.character.importance === 'lead' ? 2 : 0),
+      exclusivity: deal.exclusivity ?? true,
+      merchandising: deal.merchandising ?? (s.character.importance === 'lead')
     };
   });
 
-const keepContracted = (project.contractedTalent || []).filter(ct => !contracted.some(nc => nc.talentId === ct.talentId && nc.role === ct.role));
+const keepContracted = (project.contractedTalent || []).filter(ct => !contracted.some(nc => nc.talentId === ct.talentId && nc.role === ct.role && nc.characterId === ct.characterId));
 
 const updatedProject: Project = {
   ...project,
   cast: castEntries as any,
   crew: crewEntries as any,
-  contractedTalent: [...keepContracted, ...contracted],
+  contractedTalent: [...keepContracted, ...contracted] as any,
   castingConfirmed: true,
   starPowerBonus,
   currentPhase: project.currentPhase === 'development' ? 'pre-production' as any : project.currentPhase,
@@ -398,7 +417,7 @@ const updatedProject: Project = {
 
     for (const slot of slots) {
       if (!slot.talent) continue;
-      const deal = negotiatedByTalentId.get(slot.talent.id);
+      const deal = negotiatedBySlotId.get(slot.character.id);
       if (!deal) continue;
       updateTalent(slot.talent.id, {
         contractStatus: 'contracted' as const,

--- a/src/components/game/FestivalManagement.tsx
+++ b/src/components/game/FestivalManagement.tsx
@@ -7,16 +7,17 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { getFestivalById, getFestivalByWeek, getFestivalOptions } from '@/data/Festivals';
-import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
+import { listAvailableFestivalIndieProjects, createPurchasePatch, createPurchasedFestivalProject, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
 import { FinancialEngine } from './FinancialEngine';
 import type { Project } from '@/types/game';
 
 export const FestivalManagement: React.FC = () => {
-  const { game: gameState, rng, updateProject, spendStudioFunds, updateReputation } = useGameStore(
+  const { game: gameState, rng, updateProject, addProject, spendStudioFunds, updateReputation } = useGameStore(
     useShallow((s) => ({
       game: s.game,
       rng: s.rng,
       updateProject: s.updateProject,
+      addProject: s.addProject,
       spendStudioFunds: s.spendStudioFunds,
       updateReputation: s.updateReputation,
     }))
@@ -84,8 +85,12 @@ export const FestivalManagement: React.FC = () => {
       return;
     }
 
-    const patch = createPurchasePatch(selected, gameState.studio.id, gameState.studio.name, bidAmount, gameState.currentWeek, gameState.currentYear);
-    updateProject(selected.id, patch as any);
+    const purchasedProject = createPurchasedFestivalProject(selected, gameState.studio.id, gameState.studio.name, bidAmount, gameState.currentWeek, gameState.currentYear);
+    if (gameState.projects.some((project) => project.id === selected.id)) {
+      updateProject(selected.id, createPurchasePatch(selected, gameState.studio.id, gameState.studio.name, bidAmount, gameState.currentWeek, gameState.currentYear) as any);
+    } else {
+      addProject(purchasedProject);
+    }
 
     FinancialEngine.recordTransaction('expense', 'licensing', bidAmount, gameState.currentWeek, gameState.currentYear, `Acquired ${selected.title} at ${festival?.name || 'Festival'}`, selected.id);
     updateReputation(1);

--- a/src/components/game/FestivalMarketplaceModal.tsx
+++ b/src/components/game/FestivalMarketplaceModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { useGameStore } from '@/game/store';
-import { listAvailableFestivalIndieProjects, createPurchasePatch, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
+import { listAvailableFestivalIndieProjects, createPurchasePatch, createPurchasedFestivalProject, runFestivalAuctionRounds, parseFestivalBidAmount, formatFestivalBidAmount } from '@/utils/festivalMarketplace';
 import { getFestivalById } from '@/data/Festivals';
 import { FinancialEngine } from './FinancialEngine';
 
@@ -16,10 +16,11 @@ interface Props {
 }
 
 export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, festivalId }) => {
-  const { game: gameState, rng, updateProject, spendStudioFunds, updateReputation } = useGameStore((s) => ({
+  const { game: gameState, rng, updateProject, addProject, spendStudioFunds, updateReputation } = useGameStore((s) => ({
     game: s.game,
     rng: s.rng,
     updateProject: s.updateProject,
+    addProject: s.addProject,
     spendStudioFunds: s.spendStudioFunds,
     updateReputation: s.updateReputation,
   }));
@@ -68,9 +69,14 @@ export const FestivalMarketplaceModal: React.FC<Props> = ({ open, onOpenChange, 
       return;
     }
 
-    // Apply project patch
-    const patch = createPurchasePatch(selected, gameState.studio.id, gameState.studio.name, bidAmount, week, year);
-    updateProject(selected.id, patch as any);
+    // Apply project ownership. Festival listings often originate from the wider AI/fallback catalog,
+    // so add a canonical player project when the title is not already in the player's project list.
+    const purchasedProject = createPurchasedFestivalProject(selected, gameState.studio.id, gameState.studio.name, bidAmount, week, year);
+    if (gameState.projects.some((project) => project.id === selected.id)) {
+      updateProject(selected.id, createPurchasePatch(selected, gameState.studio.id, gameState.studio.name, bidAmount, week, year) as any);
+    } else {
+      addProject(purchasedProject);
+    }
 
     // Record transaction
     FinancialEngine.recordTransaction('expense', 'licensing', bidAmount, week, year, `Acquired ${selected.title} at ${festival?.name || 'Festival'}`, selected.id);

--- a/src/components/game/FranchiseManager.tsx
+++ b/src/components/game/FranchiseManager.tsx
@@ -6,20 +6,33 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Search, Star, Crown, Clock, TrendingUp, BookOpen, Sparkles, DollarSign, Info } from 'lucide-react';
+import { Search, Star, Crown, Clock, TrendingUp, BookOpen, Sparkles, DollarSign, Info, PlusCircle } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import type { Franchise } from '@/types/game';
+import { nextNumericId } from '@/utils/idAllocator';
 
 interface FranchiseManagerProps {
   onCreateProject: (franchiseId?: string, publicDomainId?: string, cost?: number) => void;
+  onCreateFranchise: (franchise: Franchise, cost?: number) => void;
 }
 
 export const FranchiseManager: React.FC<FranchiseManagerProps> = ({
-  onCreateProject
+  onCreateProject,
+  onCreateFranchise
 }) => {
   const gameState = useGameStore((s) => s.game);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedGenre, setSelectedGenre] = useState<string>('all');
   const [selectedDomain, setSelectedDomain] = useState<string>('all');
+  const [newFranchise, setNewFranchise] = useState({
+    title: '',
+    description: '',
+    genre: 'drama',
+    tone: 'light' as Franchise['tone'],
+    culturalWeight: 25,
+  });
 
   if (!gameState) {
     return <div className="p-6 text-sm text-muted-foreground">Loading franchise marketplace...</div>;
@@ -86,6 +99,58 @@ export const FranchiseManager: React.FC<FranchiseManagerProps> = ({
         return true;
       });
   })();
+
+
+  const createOriginalFranchise = () => {
+    const title = newFranchise.title.trim();
+    if (!title) return;
+
+    const cost = Math.floor(newFranchise.culturalWeight * 100000);
+    const franchise: Franchise = {
+      id: nextNumericId('franchise', franchises.map((f) => f.id)),
+      title,
+      description: newFranchise.description.trim(),
+      originDate: `${gameState.currentYear}-01-01`,
+      creatorStudioId: gameState.studio.id,
+      genre: [newFranchise.genre as any],
+      tone: newFranchise.tone,
+      entries: [],
+      status: 'active',
+      franchiseTags: ['original-ip'],
+      culturalWeight: newFranchise.culturalWeight,
+      cost: 0,
+      characterLibrary: [],
+      talentLibrary: [],
+      continuity: {
+        timelineEvents: [],
+        characterAppearances: {},
+        deaths: {},
+        relationships: [],
+        locations: [],
+        plotThreads: [],
+        warnings: [],
+      },
+      franchiseBible: {
+        worldbuilding: newFranchise.description.trim() ? [newFranchise.description.trim()] : [],
+        relationshipMap: [],
+        sequelHooks: ['Establish franchise-defining characters and recurring hooks in the first entry.'],
+        plannedArc: 'standalone',
+      },
+    };
+
+    onCreateFranchise(franchise, cost);
+    setNewFranchise({ title: '', description: '', genre: 'drama', tone: 'light', culturalWeight: 25 });
+  };
+
+  const acquireFranchise = (franchise: Franchise) => {
+    onCreateFranchise({
+      ...franchise,
+      creatorStudioId: gameState.studio.id,
+      cost: 0,
+      status: 'active',
+      franchiseTags: Array.from(new Set([...(franchise.franchiseTags || []), 'licensed-ip'])),
+    }, franchise.cost);
+  };
 
   const getFranchiseStatusColor = (status: string) => {
     switch (status) {
@@ -168,8 +233,9 @@ export const FranchiseManager: React.FC<FranchiseManagerProps> = ({
 
       <Tabs defaultValue="franchises" className="space-y-4">
         <TabsList>
-          <TabsTrigger value="franchises">Available Franchises ({filteredFranchises.length})</TabsTrigger>
-          <TabsTrigger value="public-domain">Public Domain ({publicDomainIPs.length})</TabsTrigger>
+          <TabsTrigger value="franchises">Buy Franchises ({filteredFranchises.length})</TabsTrigger>
+          <TabsTrigger value="create">Create Original</TabsTrigger>
+          <TabsTrigger value="public-domain">Public Domain ({filteredPublicDomain.length})</TabsTrigger>
         </TabsList>
 
         <TabsContent value="franchises" className="space-y-4">
@@ -260,15 +326,37 @@ export const FranchiseManager: React.FC<FranchiseManagerProps> = ({
 
                   <Button 
                     className="w-full"
-                    onClick={() => onCreateProject(franchise.id, undefined, franchise.cost)}
+                    onClick={() => acquireFranchise(franchise)}
                     variant="default"
                   >
-                    {franchise.entries.length === 0 ? 'Start Franchise' : 'Create Sequel'}
+                    Purchase Rights
                   </Button>
                 </CardContent>
               </Card>
             ))}
           </div>
+        </TabsContent>
+
+
+        <TabsContent value="create" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><PlusCircle className="h-5 w-5" />Create Original Franchise</CardTitle>
+              <CardDescription>One canonical path for new owned IP: establish the franchise here, then start films or TV entries from Your Franchises.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2"><Label htmlFor="new-franchise-title">Title</Label><Input id="new-franchise-title" value={newFranchise.title} onChange={(e) => setNewFranchise((prev) => ({ ...prev, title: e.target.value }))} placeholder="e.g. Neon Guardians" /></div>
+                <div className="space-y-2"><Label>Genre</Label><Select value={newFranchise.genre} onValueChange={(value) => setNewFranchise((prev) => ({ ...prev, genre: value }))}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="action">Action</SelectItem><SelectItem value="drama">Drama</SelectItem><SelectItem value="comedy">Comedy</SelectItem><SelectItem value="horror">Horror</SelectItem><SelectItem value="sci-fi">Sci-Fi</SelectItem><SelectItem value="fantasy">Fantasy</SelectItem><SelectItem value="thriller">Thriller</SelectItem><SelectItem value="romance">Romance</SelectItem></SelectContent></Select></div>
+              </div>
+              <div className="space-y-2"><Label htmlFor="new-franchise-description">Concept</Label><Textarea id="new-franchise-description" value={newFranchise.description} onChange={(e) => setNewFranchise((prev) => ({ ...prev, description: e.target.value }))} placeholder="Describe the franchise premise, world, and recurring hook..." rows={3} /></div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2"><Label>Tone</Label><Select value={newFranchise.tone} onValueChange={(value) => setNewFranchise((prev) => ({ ...prev, tone: value as Franchise['tone'] }))}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="light">Light</SelectItem><SelectItem value="dark">Dark</SelectItem><SelectItem value="pulpy">Pulpy</SelectItem><SelectItem value="serious">Serious</SelectItem><SelectItem value="comedic">Comedic</SelectItem><SelectItem value="epic">Epic</SelectItem></SelectContent></Select></div>
+                <div className="space-y-2"><Label htmlFor="new-franchise-weight">Launch Investment: ${(newFranchise.culturalWeight * 100000 / 1000000).toFixed(1)}M</Label><Input id="new-franchise-weight" type="range" min="5" max="80" value={newFranchise.culturalWeight} onChange={(e) => setNewFranchise((prev) => ({ ...prev, culturalWeight: Number(e.target.value) }))} /></div>
+              </div>
+              <Button onClick={createOriginalFranchise} disabled={!newFranchise.title.trim()} className="w-full">Create Franchise</Button>
+            </CardContent>
+          </Card>
         </TabsContent>
 
         <TabsContent value="public-domain" className="space-y-4">

--- a/src/components/game/SequelManagement.tsx
+++ b/src/components/game/SequelManagement.tsx
@@ -317,6 +317,7 @@ export const SequelManagement: React.FC<SequelManagementProps> = ({
       franchiseId,
       medium: sequelPlan.medium,
       originalProject: selectedProject,
+      franchise: gameState.franchises.find((f) => f.id === franchiseId),
       returningCast: sequelPlan.returningCast,
       getCharacterKey,
     });

--- a/src/components/game/StudioMagnateGame.tsx
+++ b/src/components/game/StudioMagnateGame.tsx
@@ -3291,6 +3291,29 @@ export const StudioMagnateGame: React.FC<StudioMagnateGameProps> = ({
               }}
             />
             <FranchiseManager
+              onCreateFranchise={(franchise, cost = 0) => {
+                if (cost > gameState.studio.budget) {
+                  toast({
+                    title: "Insufficient Budget",
+                    description: `Cannot afford this franchise - need ${(cost / 1000000).toFixed(1)}M`,
+                    variant: "destructive"
+                  });
+                  return;
+                }
+
+                if (cost > 0) {
+                  updateBudget(-cost);
+                }
+
+                handleCreateFranchise(franchise);
+
+                toast({
+                  title: cost > 0 ? "Franchise Rights Purchased" : "Original Franchise Created",
+                  description: cost > 0
+                    ? `Spent ${(cost / 1000000).toFixed(1)}M. Start entries from Your Franchises.`
+                    : `"${franchise.title}" is now available in Your Franchises.`,
+                });
+              }}
               onCreateProject={(franchiseId, publicDomainId, cost) => {
                 // Use existing handleCreateProject logic but adapted for the new interface
                 if (cost && cost > gameState.studio.budget) {

--- a/src/components/game/TalentNegotiationDialog.tsx
+++ b/src/components/game/TalentNegotiationDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import type { Project, Studio, TalentPerson } from '@/types/game';
 import {
@@ -19,6 +20,10 @@ export interface TalentNegotiationDialogAccepted {
   askWeeklyPay: number;
   weeklyPay: number;
   contractWeeks: number;
+  contractScope: 'project' | 'multi-picture' | 'exclusive';
+  sequelOptions: number;
+  exclusivity: boolean;
+  merchandising: boolean;
 }
 
 interface TalentNegotiationDialogProps {
@@ -59,6 +64,10 @@ export const TalentNegotiationDialog: React.FC<TalentNegotiationDialogProps> = (
 
   const [contractWeeks, setContractWeeks] = useState<number>(defaultWeeks);
   const [offerWeeklyPay, setOfferWeeklyPay] = useState<number>(0);
+  const [contractScope, setContractScope] = useState<'project' | 'multi-picture' | 'exclusive'>('project');
+  const [sequelOptions, setSequelOptions] = useState<number>(importance === 'lead' ? 1 : 0);
+  const [exclusivity, setExclusivity] = useState<boolean>(requiredType === 'director' || importance === 'lead');
+  const [merchandising, setMerchandising] = useState<boolean>(importance === 'lead');
   const [counter, setCounter] = useState<number | null>(null);
 
   const displayAsk = useMemo(() => {
@@ -80,6 +89,10 @@ export const TalentNegotiationDialog: React.FC<TalentNegotiationDialogProps> = (
     if (!open) return;
     setContractWeeks(defaultWeeks);
     setCounter(null);
+    setContractScope('project');
+    setSequelOptions(importance === 'lead' ? 1 : 0);
+    setExclusivity(requiredType === 'director' || importance === 'lead');
+    setMerchandising(importance === 'lead');
 
     const initialAsk = computeTalentAgentAsk({
       talent,
@@ -112,7 +125,7 @@ export const TalentNegotiationDialog: React.FC<TalentNegotiationDialogProps> = (
     });
 
     if (res.status === 'accepted') {
-      onAccepted(res);
+      onAccepted({ ...res, contractScope, sequelOptions, exclusivity, merchandising });
       onOpenChange(false);
       return;
     }
@@ -192,6 +205,33 @@ export const TalentNegotiationDialog: React.FC<TalentNegotiationDialogProps> = (
               />
               <div className="text-xs text-muted-foreground">Suggested: {defaultWeeks}w</div>
             </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label>Contract type</Label>
+              <Select value={contractScope} onValueChange={(value) => setContractScope(value as any)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="project">Per Movie</SelectItem>
+                  <SelectItem value="multi-picture">Multi-Picture Option</SelectItem>
+                  <SelectItem value="exclusive">Studio Exclusive</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Sequel options</Label>
+              <Input type="number" min={0} max={5} value={sequelOptions} onChange={(e) => setSequelOptions(Math.max(0, Math.min(5, Math.floor(Number(e.target.value) || 0))))} />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2 text-xs">
+            <Button type="button" size="sm" variant={exclusivity ? 'default' : 'outline'} onClick={() => setExclusivity((v) => !v)}>
+              {exclusivity ? 'Exclusive during shoot' : 'Non-exclusive'}
+            </Button>
+            <Button type="button" size="sm" variant={merchandising ? 'default' : 'outline'} onClick={() => setMerchandising((v) => !v)}>
+              {merchandising ? 'Merchandising included' : 'No merchandising'}
+            </Button>
           </div>
 
           <div className={`text-xs ${insufficientRunway ? 'text-destructive' : 'text-muted-foreground'}`}>

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -172,6 +172,10 @@ export interface ScriptCharacter {
     askWeeklyPay: number;
     negotiatedWeek: number;
     negotiatedYear: number;
+    contractScope?: 'project' | 'multi-picture' | 'exclusive';
+    sequelOptions?: number;
+    exclusivity?: boolean;
+    merchandising?: boolean;
   };
   // Franchise/IP linkage for imported roles
   franchiseId?: string; // Global franchise this role belongs to (immutable linkage)
@@ -686,6 +690,13 @@ export interface ContractedTalent {
   contractWeeks: number;
   weeksRemaining: number;
   startWeek: number;
+  projectId?: string;
+  characterId?: string;
+  roleType?: 'actor' | 'director' | 'writer' | 'producer' | 'crew';
+  contractScope?: 'project' | 'multi-picture' | 'exclusive';
+  sequelOptions?: number;
+  exclusivity?: boolean;
+  merchandising?: boolean;
 }
 
 export interface DevelopmentProgress {

--- a/src/utils/festivalMarketplace.ts
+++ b/src/utils/festivalMarketplace.ts
@@ -58,6 +58,20 @@ export function listAvailableFestivalIndieProjects(state: GameState, festivalId?
   return fallbackCandidates.length > 0 ? fallbackCandidates : candidates;
 }
 
+export function createPurchasedFestivalProject(
+  project: Project,
+  buyerStudioId: string,
+  buyerStudioName: string,
+  offerAmount: number,
+  week: number,
+  year: number
+): Project {
+  return {
+    ...project,
+    ...createPurchasePatch(project, buyerStudioId, buyerStudioName, offerAmount, week, year),
+  } as Project;
+}
+
 // Create an update patch for purchasing a film's rights at festival bidding.
 export function createPurchasePatch(
   project: Project,
@@ -70,8 +84,8 @@ export function createPurchasePatch(
   const patch: Partial<Project> = {
     studioId: buyerStudioId,
     studioName: buyerStudioName,
-    status: 'ready-for-release',
-    currentPhase: 'release',
+    status: 'ready-for-marketing',
+    currentPhase: 'marketing',
     releaseStrategy: {
       type: 'wide',
       theatersCount: 0,

--- a/src/utils/sequelScripts.ts
+++ b/src/utils/sequelScripts.ts
@@ -1,4 +1,4 @@
-import type { Project, Script } from '@/types/game';
+import type { Franchise, Project, Script, ScriptCharacter } from '@/types/game';
 
 export type SequelMedium = 'film' | 'tv-series' | 'tv-limited';
 
@@ -10,6 +10,7 @@ export function createSequelScript(params: {
   franchiseId: string;
   medium: SequelMedium;
   originalProject: Project;
+  franchise?: Franchise;
   returningCast: Array<{ characterId: string; talentId: string; confirmed: boolean }>;
   getCharacterKey: (c: { id: string; franchiseCharacterId?: string; roleTemplateId?: string }) => string;
 }): Script {
@@ -21,6 +22,7 @@ export function createSequelScript(params: {
     franchiseId,
     medium,
     originalProject,
+    franchise,
     returningCast,
     getCharacterKey,
   } = params;
@@ -34,15 +36,83 @@ export function createSequelScript(params: {
 
   const pacing = isTv ? 'episodic' : 'fast-paced';
 
+  const libraryCharacters = (franchise?.characterLibrary || [])
+    .filter((character) => character.status === 'active')
+    .filter((character) => character.narrativeImportance !== 'cameo' && character.narrativeImportance !== 'minor');
+
+  const castContinuityFromLibrary = (franchise?.talentLibrary || [])
+    .filter((talent) => talent.characterId && talent.continuityPreference === 'return')
+    .map((talent) => ({ characterId: talent.characterId!, talentId: talent.talentId, confirmed: talent.status !== 'retired' }));
+
   const confirmedReturning = returningCast.length > 0
     ? returningCast
-    : (base?.characters || [])
-        .filter((char) => char.assignedTalentId && (char.importance === 'lead' || char.importance === 'supporting' || char.importance === 'crew'))
-        .map((char) => ({ characterId: getCharacterKey(char), talentId: char.assignedTalentId!, confirmed: true }));
+    : [
+        ...(base?.characters || [])
+          .filter((char) => char.assignedTalentId && (char.importance === 'lead' || char.importance === 'supporting' || char.importance === 'crew'))
+          .map((char) => ({ characterId: getCharacterKey(char), talentId: char.assignedTalentId!, confirmed: true })),
+        ...castContinuityFromLibrary,
+      ];
 
-  const continuityNotes = (originalProject.contractedTalent || [])
-    .filter((t) => ['Director', 'Writer', 'Producer'].includes(t.role))
-    .map((t) => `Returning ${t.role} hold: ${t.talentId}`);
+  const returningByCharacter = new Map(
+    confirmedReturning
+      .filter((cast) => cast.confirmed)
+      .map((cast) => [cast.characterId, cast.talentId])
+  );
+
+  const charactersByKey = new Map<string, ScriptCharacter>();
+  for (const char of base?.characters || []) {
+    const key = getCharacterKey(char);
+    charactersByKey.set(key, {
+      ...char,
+      franchiseId,
+      franchiseCharacterId: char.franchiseCharacterId || key,
+      assignedTalentId: returningByCharacter.get(key),
+    });
+  }
+
+  for (const character of libraryCharacters) {
+    if (charactersByKey.has(character.characterId)) {
+      const existing = charactersByKey.get(character.characterId)!;
+      charactersByKey.set(character.characterId, {
+        ...existing,
+        name: character.name || existing.name,
+        description: character.description || existing.description,
+        ageRange: character.ageRange || existing.ageRange,
+        requiredGender: character.gender || existing.requiredGender,
+        importance: character.narrativeImportance === 'lead' ? 'lead' : 'supporting',
+        traits: character.traits || existing.traits,
+        relationships: character.relationships || existing.relationships,
+        locked: true,
+        assignedTalentId: returningByCharacter.get(character.characterId) || existing.assignedTalentId,
+      });
+      continue;
+    }
+
+    charactersByKey.set(character.characterId, {
+      id: character.characterId,
+      name: character.name,
+      description: character.description,
+      importance: character.narrativeImportance === 'lead' ? 'lead' : 'supporting',
+      requiredType: 'actor',
+      requiredGender: character.gender,
+      ageRange: character.ageRange,
+      traits: character.traits,
+      relationships: character.relationships,
+      franchiseId,
+      franchiseCharacterId: character.characterId,
+      locked: true,
+      assignedTalentId: returningByCharacter.get(character.characterId),
+    });
+  }
+
+  const continuityNotes = [
+    ...(originalProject.contractedTalent || [])
+      .filter((t) => ['Director', 'Writer', 'Producer'].includes(t.role))
+      .map((t) => `Returning ${t.role} hold: ${t.talentId}`),
+    ...(franchise?.continuity?.plotThreads || [])
+      .filter((thread) => thread.status === 'active')
+      .map((thread) => `Active franchise arc: ${thread.description}`),
+  ];
 
   return {
     id,
@@ -66,12 +136,7 @@ export function createSequelScript(params: {
       cgiIntensity: isTv ? 'minimal' : 'moderate',
       content: (base?.characteristics as any)?.content,
     } as any,
-    characters: (base?.characters || []).map((char) => ({
-      ...char,
-      assignedTalentId:
-        confirmedReturning.find((cast) => cast.characterId === getCharacterKey(char) && cast.confirmed)?.talentId ||
-        undefined,
-    })),
+    characters: Array.from(charactersByKey.values()),
     themes: Array.from(new Set([...(base?.themes || ['adventure', 'friendship']), ...continuityNotes])),
     franchiseId,
     sourceType: 'franchise',

--- a/tests/festivalIndieSupplySystem.test.ts
+++ b/tests/festivalIndieSupplySystem.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { GameState, TalentPerson } from '@/types/game';
 import { FestivalIndieSupplySystem, seedFestivalIndieProjectsForWeek } from '@/game/systems/festivalIndieSupplySystem';
-import { createPurchasePatch, listAvailableFestivalIndieProjects } from '@/utils/festivalMarketplace';
+import { createPurchasePatch, createPurchasedFestivalProject, listAvailableFestivalIndieProjects } from '@/utils/festivalMarketplace';
 import { createRng } from '@/game/core/rng';
 import type { TickContext } from '@/game/core/types';
 
@@ -94,9 +94,35 @@ describe('FestivalIndieSupplySystem', () => {
 
     const patch = createPurchasePatch(project, 'studio-1', 'Test Studio', 1_000_000, 10, 2025);
 
-    expect(patch.status).toBe('ready-for-release');
+    expect(patch.status).toBe('ready-for-marketing');
+    expect(patch.currentPhase).toBe('marketing');
     expect((patch as any).releaseStrategy?.type).toBe('wide');
     expect((patch as any).metrics?.acquiredFromFestival).toBe(true);
+  });
+
+
+  it('creates a player-owned project copy for festival auction acquisitions', () => {
+    const project = {
+      id: 'festival-ai-1',
+      title: 'Acquired Festival Film',
+      studioId: 'ai-studio',
+      studioName: 'Rival Indie',
+      status: 'draft',
+      currentPhase: 'development',
+      budget: { total: 5_000_000 },
+      script: { quality: 60, genre: 'drama', characteristics: { commercialAppeal: 5 } },
+      releaseStrategy: { type: 'festival', festivalId: 'cannes-like' },
+    } as any;
+
+    const purchased = createPurchasedFestivalProject(project, 'studio-1', 'Test Studio', 1_000_000, 10, 2025) as any;
+
+    expect(purchased.id).toBe(project.id);
+    expect(purchased.studioId).toBe('studio-1');
+    expect(purchased.studioName).toBe('Test Studio');
+    expect(purchased.status).toBe('ready-for-marketing');
+    expect(purchased.currentPhase).toBe('marketing');
+    expect(purchased.releaseStrategy.type).toBe('wide');
+    expect(purchased.metrics.acquiredFromFestival).toBe(true);
   });
 
   it('does not duplicate projects when run again for the same festival year', () => {

--- a/tests/sequelScripts.test.ts
+++ b/tests/sequelScripts.test.ts
@@ -90,4 +90,77 @@ describe('createSequelScript', () => {
     expect(script.characters?.find((c: any) => c.id === 'c-1')?.assignedTalentId).toBe('a-1');
     expect(script.characters?.find((c: any) => c.id === 'c-2')?.assignedTalentId).toBe('a-2');
   });
+
+  it('imports active franchise library characters and returning talent into sequel drafts', () => {
+    const script = createSequelScript({
+      id: 's-5',
+      title: 'Original: Legacy',
+      description: 'Library-driven sequel',
+      budget: 40_000_000,
+      franchiseId: 'f-1',
+      medium: 'film',
+      originalProject: baseProject,
+      returningCast: [],
+      getCharacterKey: (c) => c.franchiseCharacterId || c.id,
+      franchise: {
+        id: 'f-1',
+        title: 'Original Saga',
+        originDate: '2025-01-01',
+        creatorStudioId: 'studio-1',
+        genre: ['drama'],
+        tone: 'serious',
+        entries: ['p-1'],
+        status: 'active',
+        franchiseTags: [],
+        culturalWeight: 70,
+        cost: 0,
+        characterLibrary: [
+          {
+            characterId: 'c-1',
+            name: 'Avery Vale',
+            description: 'The established lead whose choices anchor the saga.',
+            ageRange: [35, 50],
+            gender: 'Male',
+            narrativeImportance: 'lead',
+            recurrencePotential: 95,
+            status: 'active',
+            appearances: ['p-1'],
+          },
+          {
+            characterId: 'c-3',
+            name: 'Mira Cross',
+            description: 'A recurring ally introduced in the franchise bible.',
+            ageRange: [30, 45],
+            gender: 'Female',
+            narrativeImportance: 'supporting',
+            recurrencePotential: 85,
+            status: 'active',
+            appearances: ['p-1'],
+          },
+        ],
+        talentLibrary: [
+          { talentId: 'a-3', name: 'Actor Three', role: 'actor', characterId: 'c-3', projectIds: ['p-1'], continuityPreference: 'return', status: 'available' },
+        ],
+        continuity: {
+          timelineEvents: [],
+          characterAppearances: { 'c-3': ['p-1'] },
+          deaths: {},
+          relationships: [],
+          locations: [],
+          plotThreads: [{ id: 'arc-1', description: 'The missing city is still unresolved.', status: 'active', appearances: ['p-1'] }],
+          warnings: [],
+        },
+      } as any,
+    });
+
+    const lead = script.characters?.find((c: any) => c.franchiseCharacterId === 'c-1') as any;
+    const recurring = script.characters?.find((c: any) => c.franchiseCharacterId === 'c-3') as any;
+
+    expect(lead.name).toBe('Avery Vale');
+    expect(lead.description).toContain('established lead');
+    expect(recurring.name).toBe('Mira Cross');
+    expect(recurring.assignedTalentId).toBe('a-3');
+    expect(script.themes).toContain('Active franchise arc: The missing city is still unresolved.');
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Add richer contract metadata (scope, sequel options, exclusivity, merchandising) to support multi-picture deals and merchandising/exclusivity flags in negotiations and contracted records.
- Ensure festival marketplace acquisitions can create a player-owned project copy when acquiring AI/fallback festival listings, and move acquired projects into a marketing-ready phase instead of immediately releasing them.
- Provide tools to create or purchase franchises in-game and to wire franchise creation into the main game flow with budget handling and toasts.
- Improve sequel/script generation so franchise character libraries and franchise talent continuity are imported into sequel drafts.

### Description
- Extend negotiation UI and flow by adding new fields to `TalentNegotiationDialog` (`contractScope`, `sequelOptions`, `exclusivity`, `merchandising`) and propagate them through `finalizeAssignment` and casting confirmation logic; store these onto `ScriptCharacter.negotiatedContract` and `ContractedTalent` entries.
- Change casting flow to key negotiated deals by slot (character id) instead of talent id and apply `contractScope`, `sequelOptions`, `exclusivity`, and `merchandising` when creating `contractedTalent` entries and when computing contract terms and budget impacts.
- Update festival marketplace utilities by adding `createPurchasedFestivalProject` and change `createPurchasePatch` to set acquired projects to `currentPhase: 'marketing'` and `status: 'ready-for-marketing'` with a wide release template.
- Update `FestivalManagement` and `FestivalMarketplaceModal` to use `addProject` when acquiring festival projects that are not already in the player's `projects` list, otherwise use `updateProject` with the purchase patch.
- Add a new franchise creation UI and flow in `FranchiseManager` with a `create` tab, `createOriginalFranchise` helper, and `acquireFranchise` path; expose `onCreateFranchise` prop to the parent.
- Wire `onCreateFranchise` into `StudioMagnateGame` to deduct budget and call `handleCreateFranchise`, with appropriate toasts for purchasing or creating franchises.
- Enhance sequel/script creation in `createSequelScript` to import characters from a franchise's `characterLibrary` and returning continuity from `talentLibrary`, include continuity notes, and preserve returning talent assignments.
- Add new helper types and fields to `types/game.ts` for the extended contract and contracted talent metadata.

### Testing
- Ran unit tests under `tests/festivalIndieSupplySystem.test.ts` which were updated to expect `ready-for-marketing`/`marketing` state and to validate `createPurchasedFestivalProject`; these tests passed.
- Ran unit tests under `tests/sequelScripts.test.ts` which were extended to validate importing franchise character library and returning talent into sequel drafts; these tests passed.
- Ran the full test suite (`vitest`) locally for modified modules and verified no regressions in the updated areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e98ef629c8322aa87400f71baccec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer talent contract options, including contract scope, sequel options, exclusivity, and merchandising rights.
  * Added tools to create original franchises and purchase franchise rights.
  * Improved sequel creation with franchise characters, returning talent, and continuity details.
  * Festival acquisitions now appear as marketing-ready projects, including projects not previously in the player’s list.

* **Bug Fixes**
  * Improved preservation and association of negotiated talent and project details during casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->